### PR TITLE
Basic Package testmempoolaccept

### DIFF
--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -899,10 +899,24 @@ class CCoinsViewMemPool : public CCoinsViewBacked
 {
 protected:
     const CTxMemPool& mempool;
+    std::map<COutPoint, Coin> cache_package_add;
+    std::map<COutPoint, Coin> cache_package_remove;
+    std::set<uint256> package_txids;
 
 public:
     CCoinsViewMemPool(CCoinsView* baseIn, const CTxMemPool& mempoolIn);
-    bool GetCoin(const COutPoint &outpoint, Coin &coin) const override;
+    bool GetCoin(const COutPoint& outpoint, Coin& coin) const override;
+    void AddPackageTransaction(const CTransactionRef& tx, int nHeight);
+    void ClearPackageCaches() {
+        cache_package_add.clear();
+        cache_package_remove.clear();
+    }
+    bool PackageContains(uint256 txid) const {
+        return package_txids.count(txid) != 0;
+    }
+    bool PackageSpends(const COutPoint& outpoint) const {
+        return cache_package_remove.count(outpoint) != 0;
+    }
 };
 
 /**

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -673,11 +673,6 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, ATMPResult& result, Workspace& ws)
     // Bring the best block into scope
     m_view.GetBestBlock();
 
-    // we have all inputs cached now, so switch back to dummy (to protect
-    // against bugs where we pull more inputs from disk that miss being added
-    // to coins_to_uncache)
-    m_view.SetBackend(m_dummy);
-
     // Only accept BIP68 sequence locked transactions that can be mined in the next
     // block; we don't want our mempool filled up with transactions that can't
     // be mined yet.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -253,10 +253,9 @@ bool TestLockPointValidity(const LockPoints* lp)
     return true;
 }
 
-bool CheckSequenceLocks(const CTxMemPool& pool, const CTransaction& tx, int flags, LockPoints* lp, bool useExistingLockPoints)
+bool CheckSequenceLocks(CCoinsView& view, const CTransaction& tx, int flags, LockPoints* lp, bool useExistingLockPoints)
 {
     AssertLockHeld(cs_main);
-    AssertLockHeld(pool.cs);
 
     CBlockIndex* tip = ::ChainActive().Tip();
     assert(tip != nullptr);
@@ -279,13 +278,12 @@ bool CheckSequenceLocks(const CTxMemPool& pool, const CTransaction& tx, int flag
     }
     else {
         // CoinsTip() contains the UTXO set for ::ChainActive().Tip()
-        CCoinsViewMemPool viewMemPool(&::ChainstateActive().CoinsTip(), pool);
         std::vector<int> prevheights;
         prevheights.resize(tx.vin.size());
         for (size_t txinIndex = 0; txinIndex < tx.vin.size(); txinIndex++) {
             const CTxIn& txin = tx.vin[txinIndex];
             Coin coin;
-            if (!viewMemPool.GetCoin(txin.prevout, coin)) {
+            if (!view.GetCoin(txin.prevout, coin)) {
                 return error("%s: Missing input", __func__);
             }
             if (coin.nHeight == MEMPOOL_HEIGHT) {
@@ -323,6 +321,15 @@ bool CheckSequenceLocks(const CTxMemPool& pool, const CTransaction& tx, int flag
         }
     }
     return EvaluateSequenceLocks(index, lockPair);
+}
+
+bool CheckSequenceLocks(const CTxMemPool& pool, const CTransaction& tx, int flags, LockPoints* lp, bool useExistingLockPoints)
+{
+    AssertLockHeld(cs_main);
+    AssertLockHeld(pool.cs);
+    CCoinsViewMemPool viewMemPool(&::ChainstateActive().CoinsTip(), pool);
+    CCoinsView& view(viewMemPool);
+    return CheckSequenceLocks(view, tx, flags, lp, useExistingLockPoints);
 }
 
 // Returns the script flags which should be checked for a given block
@@ -673,7 +680,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, ATMPResult& result, Workspace& ws)
     // be mined yet.
     // Must keep pool.cs for this unless we change CheckSequenceLocks to take a
     // CoinsViewCache instead of create its own
-    if (!CheckSequenceLocks(m_pool, tx, STANDARD_LOCKTIME_VERIFY_FLAGS, &lp))
+    if (!CheckSequenceLocks(m_view, tx, STANDARD_LOCKTIME_VERIFY_FLAGS, &lp))
         return state.Invalid(TxValidationResult::TX_PREMATURE_SPEND, "non-BIP68-final");
 
     if (!Consensus::CheckTxInputs(tx, state, m_view, GetSpendHeight(m_view), result.m_fee)) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -417,7 +417,7 @@ static void UpdateMempoolForReorg(CTxMemPool& mempool, DisconnectedBlockTransact
 // Used to avoid mempool polluting consensus critical paths if CCoinsViewMempool
 // were somehow broken and returning the wrong scriptPubKeys
 static bool CheckInputsFromMempoolAndCache(const CTransaction& tx, TxValidationState& state, const CCoinsViewCache& view, const CTxMemPool& pool,
-                 unsigned int flags, PrecomputedTransactionData& txdata) EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
+                const CCoinsViewMemPool& pool_view, unsigned int flags, PrecomputedTransactionData& txdata) EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
     AssertLockHeld(cs_main);
 
     // pool.cs should be locked already, but go ahead and re-take the lock here
@@ -436,10 +436,13 @@ static bool CheckInputsFromMempoolAndCache(const CTransaction& tx, TxValidationS
 
         // Check equivalence for available inputs.
         const CTransactionRef& txFrom = pool.get(txin.prevout.hash);
+        Coin coinPrev;
         if (txFrom) {
             assert(txFrom->GetHash() == txin.prevout.hash);
             assert(txFrom->vout.size() > txin.prevout.n);
             assert(txFrom->vout[txin.prevout.n] == coin.out);
+        } else if (pool_view.GetCoin(txin.prevout, coinPrev)) {
+            // TODO: maybe actually check the prev transaction instead
         } else {
             const Coin& coinFromDisk = ::ChainstateActive().CoinsTip().AccessCoin(txin.prevout);
             assert(!coinFromDisk.IsSpent());
@@ -970,7 +973,7 @@ bool MemPoolAccept::ConsensusScriptChecks(ATMPArgs& args, ATMPResult& result, Wo
     // invalid blocks (using TestBlockValidity), however allowing such
     // transactions into the mempool can be exploited as a DoS attack.
     unsigned int currentBlockScriptVerifyFlags = GetBlockScriptFlags(::ChainActive().Tip(), chainparams.GetConsensus());
-    if (!CheckInputsFromMempoolAndCache(tx, state, m_view, m_pool, currentBlockScriptVerifyFlags, txdata)) {
+    if (!CheckInputsFromMempoolAndCache(tx, state, m_view, m_pool, m_viewmempool, currentBlockScriptVerifyFlags, txdata)) {
         return error("%s: BUG! PLEASE REPORT THIS! CheckInputScripts failed against latest-block but not STANDARD flags %s, %s",
                 __func__, hash.ToString(), state.ToString());
     }

--- a/src/validation.h
+++ b/src/validation.h
@@ -12,6 +12,7 @@
 
 #include <amount.h>
 #include <coins.h>
+#include <consensus/validation.h>
 #include <crypto/common.h> // for ReadLE64
 #include <fs.h>
 #include <optional.h>
@@ -45,7 +46,6 @@ class CScriptCheck;
 class CBlockPolicyEstimator;
 class CTxMemPool;
 class ChainstateManager;
-class TxValidationState;
 struct ChainTxData;
 
 struct DisconnectedBlockTransactions;
@@ -202,6 +202,17 @@ void PruneBlockFilesManual(int nManualPruneHeight);
 bool AcceptToMemoryPool(CTxMemPool& pool, TxValidationState &state, const CTransactionRef &tx,
                         std::list<CTransactionRef>* plTxnReplaced,
                         bool bypass_limits, bool test_accept=false, CAmount* fee_out=nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
+/** Per-transaction result of calling ATMP */
+struct ATMPResult {
+    ATMPResult(const CTransactionRef& ptx) : txid(ptx->GetHash()) {}
+    ATMPResult(uint256 txid, bool allowed, TxValidationState state, CAmount fee) : txid(txid), m_accepted(allowed), m_state(state), m_fee(fee) {}
+    uint256 txid;
+    bool m_accepted = false;
+    TxValidationState m_state;
+    std::list<CTransactionRef> m_replaced_transactions{};
+    CAmount m_fee = CAmount(0);
+};
 
 /** Get the BIP9 state for a given deployment at the current tip. */
 ThresholdState VersionBitsTipState(const Consensus::Params& params, Consensus::DeploymentPos pos);

--- a/src/validation.h
+++ b/src/validation.h
@@ -256,6 +256,9 @@ bool TestLockPointValidity(const LockPoints* lp) EXCLUSIVE_LOCKS_REQUIRED(cs_mai
  */
 bool CheckSequenceLocks(const CTxMemPool& pool, const CTransaction& tx, int flags, LockPoints* lp = nullptr, bool useExistingLockPoints = false) EXCLUSIVE_LOCKS_REQUIRED(::cs_main, pool.cs);
 
+// A version that uses a view (so that you can reuse the view across calls)
+bool CheckSequenceLocks(CCoinsView& view, const CTransaction& tx, int flags, LockPoints* lp = nullptr, bool useExistingLockPoints = false) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
 /**
  * Closure representing one script verification
  * Note that this stores references to the spending transaction

--- a/src/validation.h
+++ b/src/validation.h
@@ -214,6 +214,12 @@ struct ATMPResult {
     CAmount m_fee = CAmount(0);
 };
 
+/** Test acceptance of multiple transactions.
+* Applies validation and mempool policy logic to each one individually.
+* Returns a the ATMPResult for each transaction in the order they were passed in.
+*/
+std::vector<ATMPResult> AcceptPackageToMemoryPool(CTxMemPool& pool, std::vector<const CTransactionRef>& txns, bool test_accept) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
 /** Get the BIP9 state for a given deployment at the current tip. */
 ThresholdState VersionBitsTipState(const Consensus::Params& params, Consensus::DeploymentPos pos);
 


### PR DESCRIPTION
Extremely basic (and ugly) implementation of package testmempoolaccept. The cpp code is pretty atrocious too, please don't judge.
Uses `CoinsViewMemPool` to persist knowledge about inputs across transactions without actually submitting to mempool.
Still todo, `PreChecks` for each transaction first before getting into script checking for better performance and to fail faster.
Requires ordering by dependency, so we also need a `sortPackage` function if this would be used for packages from p2p (txrelay shouldn't have ordering guarantees).