### PR TITLE
Package Relay Draft 1 (Single In-Flight Approach)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -219,6 +219,7 @@ BITCOIN_CORE_H = \
   node/minisketchwrapper.h \
   node/psbt.h \
   node/transaction.h \
+  node/txpackagetracker.h \
   node/txreconciliation.h \
   node/utxo_snapshot.h \
   node/validation_cache_args.h \
@@ -410,6 +411,7 @@ libbitcoin_node_a_SOURCES = \
   node/minisketchwrapper.cpp \
   node/psbt.cpp \
   node/transaction.cpp \
+  node/txpackagetracker.cpp \
   node/txreconciliation.cpp \
   node/utxo_snapshot.cpp \
   node/validation_cache_args.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -150,6 +150,7 @@ BITCOIN_TESTS =\
   test/translation_tests.cpp \
   test/txindex_tests.cpp \
   test/txpackage_tests.cpp \
+  test/txpackagetracker_tests.cpp \
   test/txreconciliation_tests.cpp \
   test/txrequest_tests.cpp \
   test/txvalidation_tests.cpp \

--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -54,6 +54,7 @@ enum class TxValidationResult {
     TX_CONFLICT,
     TX_MEMPOOL_POLICY,        //!< violated mempool's fee/size/descendant/RBF/etc limits
     TX_NO_MEMPOOL,            //!< this node does not have a mempool so can't validate the transaction
+    TX_LOW_FEE,               //!< fee was insufficient to meet some policy (minimum/RBF/etc)
 };
 
 /** A "reason" why a block was invalid, suitable for determining whether the

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -46,6 +46,7 @@
 #include <node/mempool_args.h>
 #include <node/mempool_persist_args.h>
 #include <node/miner.h>
+#include <node/txpackagetracker.h>
 #include <node/txreconciliation.h>
 #include <node/validation_cache_args.h>
 #include <policy/feerate.h>
@@ -488,6 +489,7 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-i2psam=<ip:port>", "I2P SAM proxy to reach I2P peers and accept I2P connections (default: none)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-i2pacceptincoming", strprintf("Whether to accept inbound I2P connections (default: %i). Ignored if -i2psam is not set. Listening for inbound I2P connections is done through the SAM proxy, not by binding to a local address and port.", DEFAULT_I2P_ACCEPT_INCOMING), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-onlynet=<net>", "Make automatic outbound connections only to network <net> (" + Join(GetNetworkNames(), ", ") + "). Inbound and manual connections are not affected by this option. It can be specified multiple times to allow multiple networks.", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
+    argsman.AddArg("-packagerelay", strprintf("[EXPERIMENTAL] Support relaying transaction packages (default: %u)", node::DEFAULT_ENABLE_PACKAGE_RELAY), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-peerbloomfilters", strprintf("Support filtering of blocks and transaction with bloom filters (default: %u)", DEFAULT_PEERBLOOMFILTERS), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-peerblockfilters", strprintf("Serve compact block filters to peers per BIP 157 (default: %u)", DEFAULT_PEERBLOCKFILTERS), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-txreconciliation", strprintf("Enable transaction reconciliations per BIP 330 (default: %d)", DEFAULT_TXRECONCILIATION_ENABLE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CONNECTION);
@@ -1551,10 +1553,11 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     }
 
     ChainstateManager& chainman = *Assert(node.chainman);
+    const bool enable_package_relay{gArgs.GetBoolArg("-packagerelay", node::DEFAULT_ENABLE_PACKAGE_RELAY)};
 
     assert(!node.peerman);
     node.peerman = PeerManager::make(*node.connman, *node.addrman, node.banman.get(),
-                                     chainman, *node.mempool, ignores_incoming_txs);
+                                     chainman, *node.mempool, ignores_incoming_txs, enable_package_relay);
     RegisterValidationInterface(node.peerman.get());
 
     // ********************************************************* Step 8: start indexers

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -182,6 +182,7 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::BLOCKSTORE, "blockstorage"},
     {BCLog::TXRECONCILIATION, "txreconciliation"},
     {BCLog::SCAN, "scan"},
+    {BCLog::TXPACKAGES, "txpackages"},
     {BCLog::ALL, "1"},
     {BCLog::ALL, "all"},
 };
@@ -286,6 +287,8 @@ std::string LogCategoryToStr(BCLog::LogFlags category)
         return "txreconciliation";
     case BCLog::LogFlags::SCAN:
         return "scan";
+    case BCLog::LogFlags::TXPACKAGES:
+        return "txpackages";
     case BCLog::LogFlags::ALL:
         return "all";
     }

--- a/src/logging.h
+++ b/src/logging.h
@@ -68,6 +68,7 @@ namespace BCLog {
         BLOCKSTORE  = (1 << 26),
         TXRECONCILIATION = (1 << 27),
         SCAN        = (1 << 28),
+        TXPACKAGES  = (1 << 29),
         ALL         = ~(uint32_t)0,
     };
     enum class Level {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4850,6 +4850,46 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         return;
     }
 
+    if (msg_type == NetMsgType::GETPKGTXNS) {
+        unsigned int num_txns = ReadCompactSize(vRecv);
+        if (num_txns == 0 || num_txns > MAX_PACKAGE_COUNT) {
+            Misbehaving(*peer, 100, strprintf("getpkgtxns size = %u", num_txns));
+            return;
+        }
+        std::vector<uint256> txns_requested;
+        txns_requested.resize(num_txns);
+        for (unsigned int n = 0; n < num_txns; ++n) vRecv >> txns_requested[n];
+
+        {
+            LOCK(peer->m_getdata_requests_mutex);
+            std::vector<CTransactionRef> pkgtxns;
+            auto tx_relay = peer->GetTxRelay();
+            const auto mempool_req = tx_relay != nullptr ? tx_relay->m_last_mempool_req.load() : std::chrono::seconds::min();
+            const auto now{GetTime<std::chrono::seconds>()};
+            for (const auto& wtxid : txns_requested) {
+                auto ptx = FindTxForGetData(*tx_relay, GenTxid::Wtxid(wtxid), mempool_req, now);
+                if (ptx) {
+                    pkgtxns.push_back(ptx);
+                } else {
+                    // A getpkgtxns request is all or nothing; if any of the transactions are
+                    // unavailable, return a notfound for the full request.
+                    break;
+                }
+            }
+            if (pkgtxns.size() == txns_requested.size()) {
+                m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::PKGTXNS, pkgtxns));
+            } else {
+                std::vector<CInv> notfound{{CInv{MSG_PKGTXNS, GetCombinedHash(txns_requested)}}};
+                m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::NOTFOUND, notfound));
+            }
+        }
+    }
+
+    if (msg_type == NetMsgType::PKGTXNS) {
+        LogPrint(BCLog::NET, "pkgtxns received from peer=%d", pfrom.GetId());
+        return;
+    }
+
     if (msg_type == NetMsgType::PING) {
         if (pfrom.GetCommonVersion() > BIP0031_VERSION) {
             uint64_t nonce = 0;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -806,9 +806,14 @@ private:
         EXCLUSIVE_LOCKS_REQUIRED(cs_main, !m_recent_confirmed_transactions_mutex);
 
     /**
-     * Filter for transactions that were recently rejected by the mempool.
-     * These are not rerequested until the chain tip changes, at which point
-     * the entire filter is reset.
+     * Filter for transactions that were recently rejected by the mempool for reasons other than too
+     * low fee. This filter only contains wtxids and txids of individual transactions.
+     *
+     * Upon receiving an announcement for a transaction, if it exists in this filter, do not
+     * download the txdata. Upon receiving a package info, if it contains a transaction in this
+     * filter, do not download the tx data.
+     *
+     * Reset this filter when the chain tip changes.
      *
      * Without this filter we'd be re-requesting txs from each of our peers,
      * increasing bandwidth consumption considerably. For instance, with 100
@@ -840,6 +845,33 @@ private:
      * Memory used: 1.3 MB
      */
     CRollingBloomFilter m_recent_rejects GUARDED_BY(::cs_main){120'000, 0.000'001};
+    /**
+     * Filter for transactions or packages of transactions that were recently rejected by
+     * the mempool but are eligible for reconsideration if submitted with other transactions.
+     * This filter only contains wtxids of individual transactions and combined hashes of packages
+     * (see GetCombinedHash and GetPackageHash).
+     *
+     * When a transaction's error is TX_LOW_FEE (in a package or by itself), add its wtxid to this
+     * filter. If it was in a package, also add the combined hash of the transactions in its
+     * subpackage to this filter. When a package fails for any reason, add the combined hash of all
+     * transactions in the package info to this filter.
+     *
+     * Upon receiving an announcement for a transaction, if it exists in this filter, do not
+     * download the txdata. Upon receiving a package info, if the combined hash of its transactions
+     * are in this filter, do not download the txdata.
+     *
+     * Reset this filter when the chain tip changes.
+     *
+     * We will only add wtxids to this filter. Groups of multiple transactions are represented by
+     * the hash of their wtxids, concatenated together in lexicographical order.
+     *
+     * Parameters are picked to be identical to that of m_recent_rejects, with the same rationale.
+     * Memory used: 1.3 MB
+     * FIXME: this filter can probably be smaller, but how much smaller?
+     */
+    CRollingBloomFilter m_recent_rejects_reconsiderable GUARDED_BY(::cs_main){120'000, 0.000'001};
+    /** The block hash of the chain tip at which transactions in m_recent_rejects and
+     * m_recent_rejects_reconsiderable were rejected. */
     uint256 hashRecentRejectsChainTip GUARDED_BY(cs_main);
 
     /*
@@ -1789,6 +1821,7 @@ bool PeerManagerImpl::MaybePunishNodeForTx(NodeId nodeid, const TxValidationStat
     case TxValidationResult::TX_CONFLICT:
     case TxValidationResult::TX_MEMPOOL_POLICY:
     case TxValidationResult::TX_NO_MEMPOOL:
+    case TxValidationResult::TX_LOW_FEE:
         break;
     }
     if (message != "") {
@@ -2078,6 +2111,7 @@ bool PeerManagerImpl::AlreadyHaveTx(const GenTxid& gtxid, bool include_orphanage
         // txs a second chance.
         hashRecentRejectsChainTip = m_chainman.ActiveChain().Tip()->GetBlockHash();
         m_recent_rejects.reset();
+        m_recent_rejects_reconsiderable.reset();
     }
 
     const uint256& hash = gtxid.GetHash();
@@ -4221,7 +4255,11 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                 // See also comments in https://github.com/bitcoin/bitcoin/pull/18044#discussion_r443419034
                 // for concerns around weakening security of unupgraded nodes
                 // if we start doing this too early.
-                m_recent_rejects.insert(tx.GetWitnessHash());
+                if (state.GetResult() == TxValidationResult::TX_LOW_FEE) {
+                    m_recent_rejects_reconsiderable.insert(tx.GetWitnessHash());
+                } else {
+                    m_recent_rejects.insert(tx.GetWitnessHash());
+                }
                 m_txrequest.ForgetTxHash(tx.GetWitnessHash());
                 // If the transaction failed for TX_INPUTS_NOT_STANDARD,
                 // then we know that the witness was irrelevant to the policy

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -680,6 +680,10 @@ private:
     void AddTxAnnouncement(const CNode& node, const GenTxid& gtxid, std::chrono::microseconds current_time)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
+    /** Register with orphan TxRequestTracker that a peer may help us resolve this orphan. */
+    void AddOrphanResolutionCandidate(NodeId nodeid, const uint256& orphan_wtxid, const CTransactionRef& tx, std::chrono::microseconds current_time)
+        EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
     /** Send a version message to a peer */
     void PushNodeVersion(CNode& pnode, const Peer& peer);
 
@@ -782,7 +786,7 @@ private:
     /** Stalling timeout for blocks in IBD */
     std::atomic<std::chrono::seconds> m_block_stalling_timeout{BLOCK_STALLING_TIMEOUT_DEFAULT};
 
-    bool AlreadyHaveTx(const GenTxid& gtxid)
+    bool AlreadyHaveTx(const GenTxid& gtxid, bool include_orphanage = true)
         EXCLUSIVE_LOCKS_REQUIRED(cs_main, !m_recent_confirmed_transactions_mutex);
 
     /**
@@ -1407,6 +1411,18 @@ void PeerManagerImpl::PushNodeVersion(CNode& pnode, const Peer& peer)
     }
 }
 
+void PeerManagerImpl::AddOrphanResolutionCandidate(NodeId nodeid, const uint256& orphan_wtxid, const CTransactionRef& orphan, std::chrono::microseconds current_time)
+{
+    AssertLockHeld(::cs_main);
+    const CNodeState* state = State(nodeid);
+    // Decide the TxRequestTracker parameters for this orphan resolution:
+    // - "preferred": if fPreferredDownload is set (= outbound, or NetPermissionFlags::NoBan permission)
+    // - "reqtime": current time
+    auto delay{0us};
+    const bool preferred = state->fPreferredDownload;
+    m_txpackagetracker->AddOrphanTx(nodeid, orphan_wtxid, orphan, preferred, current_time + delay);
+}
+
 void PeerManagerImpl::AddTxAnnouncement(const CNode& node, const GenTxid& gtxid, std::chrono::microseconds current_time)
 {
     AssertLockHeld(::cs_main); // For m_txrequest
@@ -1998,7 +2014,7 @@ void PeerManagerImpl::BlockChecked(const CBlock& block, const BlockValidationSta
 //
 
 
-bool PeerManagerImpl::AlreadyHaveTx(const GenTxid& gtxid)
+bool PeerManagerImpl::AlreadyHaveTx(const GenTxid& gtxid, bool include_orphanage)
 {
     if (m_chainman.ActiveChain().Tip()->GetBlockHash() != hashRecentRejectsChainTip) {
         // If the chain tip has changed previously rejected transactions
@@ -2011,7 +2027,7 @@ bool PeerManagerImpl::AlreadyHaveTx(const GenTxid& gtxid)
 
     const uint256& hash = gtxid.GetHash();
 
-    if (m_txpackagetracker->OrphanageHaveTx(gtxid)) return true;
+    if (include_orphanage && m_txpackagetracker->OrphanageHaveTx(gtxid)) return true;
 
     {
         LOCK(m_recent_confirmed_transactions_mutex);
@@ -4047,6 +4063,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             m_txrequest.ForgetTxHash(tx.GetHash());
             m_txrequest.ForgetTxHash(tx.GetWitnessHash());
             RelayTransaction(tx.GetHash(), tx.GetWitnessHash());
+            m_txpackagetracker->FinalizeTransactions({tx.GetWitnessHash()}, {});
             m_txpackagetracker->AddChildrenToWorkSet(tx);
 
             pfrom.m_last_tx_time = GetTime<std::chrono::seconds>();
@@ -4063,38 +4080,20 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         else if (state.GetResult() == TxValidationResult::TX_MISSING_INPUTS)
         {
             bool fRejectedParents = false; // It may be the case that the orphans parents have all been rejected
-
-            // Deduplicate parent txids, so that we don't have to loop over
-            // the same parent txid more than once down below.
-            std::vector<uint256> unique_parents;
-            unique_parents.reserve(tx.vin.size());
-            for (const CTxIn& txin : tx.vin) {
-                // We start with all parents, and then remove duplicates below.
-                unique_parents.push_back(txin.prevout.hash);
-            }
-            std::sort(unique_parents.begin(), unique_parents.end());
-            unique_parents.erase(std::unique(unique_parents.begin(), unique_parents.end()), unique_parents.end());
-            for (const uint256& parent_txid : unique_parents) {
+            for (const auto& input : tx.vin) {
+                const auto& parent_txid = input.prevout.hash;
+                AddKnownTx(*peer, parent_txid);
                 if (m_recent_rejects.contains(parent_txid)) {
                     fRejectedParents = true;
                     break;
                 }
             }
             if (!fRejectedParents) {
+                const bool had_before{m_txpackagetracker->OrphanageHaveTx(GenTxid::Wtxid(ptx->GetWitnessHash()))};
                 const auto current_time{GetTime<std::chrono::microseconds>()};
+                AddOrphanResolutionCandidate(pfrom.GetId(), ptx->GetWitnessHash(), ptx, current_time);
 
-                for (const uint256& parent_txid : unique_parents) {
-                    // Here, we only have the txid (and not wtxid) of the
-                    // inputs, so we only request in txid mode, even for
-                    // wtxidrelay peers.
-                    // Eventually we should replace this with an improved
-                    // protocol for getting all unconfirmed parents.
-                    const auto gtxid{GenTxid::Txid(parent_txid)};
-                    AddKnownTx(*peer, parent_txid);
-                    if (!AlreadyHaveTx(gtxid)) AddTxAnnouncement(pfrom, gtxid, current_time);
-                }
-
-                if (m_txpackagetracker->OrphanageAddTx(ptx, pfrom.GetId())) {
+                if (!had_before && m_txpackagetracker->OrphanageHaveTx(GenTxid::Wtxid(ptx->GetWitnessHash()))) {
                     AddToCompactExtraTransactions(ptx);
                 }
 
@@ -5841,6 +5840,18 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
             }
         }
 
+        auto requestable_orphans = m_txpackagetracker->GetOrphanRequests(pto->GetId(), current_time);
+        for (const auto& gtxid : requestable_orphans) {
+            if (AlreadyHaveTx(gtxid, /*include_orphanage=*/false)) {
+                m_txpackagetracker->FinalizeTransactions({gtxid.GetHash()}, {});
+            } else {
+                vGetData.emplace_back(MSG_TX | GetFetchFlags(*peer), gtxid.GetHash());
+                if (vGetData.size() >= MAX_GETDATA_SZ) {
+                    m_connman.PushMessage(pto, msgMaker.Make(NetMsgType::GETDATA, vGetData));
+                    vGetData.clear();
+                }
+            }
+        }
 
         if (!vGetData.empty())
             m_connman.PushMessage(pto, msgMaker.Make(NetMsgType::GETDATA, vGetData));

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -263,6 +263,10 @@ struct Peer {
 
     /** Whether this peer relays txs via wtxid */
     std::atomic<bool> m_wtxid_relay{false};
+
+    /** Whether this peer relays packages */
+    std::atomic<bool> m_package_relay{false};
+
     /** The feerate in the most recent BIP133 `feefilter` message sent to the peer.
      *  It is *not* a p2p protocol violation for the peer to send us
      *  transactions with a lower fee rate than this. See BIP133. */
@@ -492,7 +496,8 @@ class PeerManagerImpl final : public PeerManager
 public:
     PeerManagerImpl(CConnman& connman, AddrMan& addrman,
                     BanMan* banman, ChainstateManager& chainman,
-                    CTxMemPool& pool, bool ignore_incoming_txs);
+                    CTxMemPool& pool, bool ignore_incoming_txs,
+                    bool enable_package_relay);
 
     /** Overridden from CValidationInterface. */
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected) override
@@ -736,6 +741,9 @@ private:
     /** Whether this node is running in -blocksonly mode */
     const bool m_ignore_incoming_txs;
 
+    /** Whether this node does package relay */
+    const bool m_enable_package_relay;
+
     bool RejectIncomingTxs(const CNode& peer) const;
 
     /** Whether we've completed initial sync yet, for determining when to turn
@@ -781,6 +789,9 @@ private:
 
     /** Number of peers with wtxid relay. */
     std::atomic<int> m_wtxid_relay_peers{0};
+
+    /** Number of peers with package relay. */
+    std::atomic<int> m_package_relay_peers{0};
 
     /** Number of outbound peers with m_chain_sync.m_protect. */
     int m_outbound_peers_with_protect_from_disconnect GUARDED_BY(cs_main) = 0;
@@ -1547,7 +1558,9 @@ void PeerManagerImpl::FinalizeNode(const CNode& node)
         assert(peer != nullptr);
         misbehavior = WITH_LOCK(peer->m_misbehavior_mutex, return peer->m_misbehavior_score);
         m_wtxid_relay_peers -= peer->m_wtxid_relay;
+        m_package_relay_peers -= peer->m_package_relay;
         assert(m_wtxid_relay_peers >= 0);
+        assert(m_package_relay_peers >= 0);
     }
     CNodeState *state = State(nodeid);
     assert(state != nullptr);
@@ -1561,6 +1574,7 @@ void PeerManagerImpl::FinalizeNode(const CNode& node)
     m_txpackagetracker->DisconnectedPeer(nodeid);
     m_txrequest.DisconnectedPeer(nodeid);
     if (m_txreconciliation) m_txreconciliation->ForgetPeer(nodeid);
+    if (m_txpackagetracker) m_txpackagetracker->DisconnectedPeer(nodeid);
     m_num_preferred_download_peers -= state->fPreferredDownload;
     m_peers_downloading_from -= (state->nBlocksInFlight != 0);
     assert(m_peers_downloading_from >= 0);
@@ -1576,6 +1590,7 @@ void PeerManagerImpl::FinalizeNode(const CNode& node)
         assert(m_peers_downloading_from == 0);
         assert(m_outbound_peers_with_protect_from_disconnect == 0);
         assert(m_wtxid_relay_peers == 0);
+        assert(m_package_relay_peers == 0);
         assert(m_txrequest.Size() == 0);
         assert(m_txpackagetracker->OrphanageSize() == 0);
     }
@@ -1830,21 +1845,24 @@ std::optional<std::string> PeerManagerImpl::FetchBlock(NodeId peer_id, const CBl
 
 std::unique_ptr<PeerManager> PeerManager::make(CConnman& connman, AddrMan& addrman,
                                                BanMan* banman, ChainstateManager& chainman,
-                                               CTxMemPool& pool, bool ignore_incoming_txs)
+                                               CTxMemPool& pool, bool ignore_incoming_txs,
+                                               bool enable_package_relay)
 {
-    return std::make_unique<PeerManagerImpl>(connman, addrman, banman, chainman, pool, ignore_incoming_txs);
+    return std::make_unique<PeerManagerImpl>(connman, addrman, banman, chainman, pool, ignore_incoming_txs, enable_package_relay);
 }
 
 PeerManagerImpl::PeerManagerImpl(CConnman& connman, AddrMan& addrman,
                                  BanMan* banman, ChainstateManager& chainman,
-                                 CTxMemPool& pool, bool ignore_incoming_txs)
+                                 CTxMemPool& pool, bool ignore_incoming_txs,
+                                 bool enable_package_relay)
     : m_chainparams(chainman.GetParams()),
       m_connman(connman),
       m_addrman(addrman),
       m_banman(banman),
       m_chainman(chainman),
       m_mempool(pool),
-      m_ignore_incoming_txs(ignore_incoming_txs)
+      m_ignore_incoming_txs(ignore_incoming_txs),
+      m_enable_package_relay{enable_package_relay}
 {
     // While Erlay support is incomplete, it must be enabled explicitly via -txreconciliation.
     // This argument can go away after Erlay support is complete.
@@ -3307,6 +3325,18 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
         if (greatest_common_version >= WTXID_RELAY_VERSION) {
             m_connman.PushMessage(&pfrom, msg_maker.Make(NetMsgType::WTXIDRELAY));
+            if (m_enable_package_relay) {
+                m_txpackagetracker->ReceivedVersion(peer->m_id);
+                if (!m_ignore_incoming_txs) {
+                    // Always send a sendpackages for each version we support if:
+                    // - Protocol version is at least WTXID_RELAY_VERSION
+                    // - We have package relay enabled
+                    // - We are not in blocksonly mode.
+                    for (const auto version : m_txpackagetracker->GetVersions()) {
+                        m_connman.PushMessage(&pfrom, msg_maker.Make(NetMsgType::SENDPACKAGES, version));
+                    }
+                }
+            }
         }
 
         // Signal ADDRv2 support (BIP155).
@@ -3494,6 +3524,10 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                        tx_relay->m_next_inv_send_time == 0s));
         }
 
+        if (m_enable_package_relay && m_txpackagetracker->ReceivedVerack(peer->m_id, pfrom.m_relays_txs, peer->m_wtxid_relay)) {
+            peer->m_package_relay = true;
+            m_package_relay_peers++;
+        }
         pfrom.fSuccessfullyConnected = true;
         return;
     }
@@ -3518,6 +3552,23 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         // save whether peer selects us as BIP152 high-bandwidth peer
         // (receiving sendcmpct(1) signals high-bandwidth, sendcmpct(0) low-bandwidth)
         pfrom.m_bip152_highbandwidth_from = sendcmpct_hb;
+        return;
+    }
+
+    if (msg_type == NetMsgType::SENDPACKAGES) {
+        if (m_enable_package_relay) {
+            if (pfrom.fSuccessfullyConnected) {
+                // Disconnect peers that send a SENDPACKAGES message after VERACK.
+                LogPrint(BCLog::NET, "sendpackages received after verack from peer=%d; disconnecting\n", pfrom.GetId());
+                pfrom.fDisconnect = true;
+                return;
+            }
+            uint32_t sendpackages_version{0};
+            vRecv >> sendpackages_version;
+            m_txpackagetracker->ReceivedSendpackages(peer->m_id, sendpackages_version);
+        } else {
+            LogPrintLevel(BCLog::NET, BCLog::Level::Debug, "sendpackages from peer=%d ignored, as our node does not have package relay enabled\n", pfrom.GetId());
+        }
         return;
     }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -603,6 +603,10 @@ private:
     bool ProcessOrphanTx(Peer& peer)
         EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex, g_msgproc_mutex);
 
+    /** Validate package if any */
+    void ProcessPackage(CNode& node, const node::TxPackageTracker::PackageToValidate& package)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex, g_msgproc_mutex);
+
     /** Process a single headers message from a peer.
      *
      * @param[in]   pfrom     CNode of the peer
@@ -3133,6 +3137,78 @@ bool PeerManagerImpl::ProcessOrphanTx(Peer& peer)
     return false;
 }
 
+void PeerManagerImpl::ProcessPackage(CNode& node, const node::TxPackageTracker::PackageToValidate& package)
+{
+    AssertLockHeld(g_msgproc_mutex);
+    LOCK(cs_main);
+    // We won't re-validate the exact same transaction or package again.
+    if (m_recent_rejects_reconsiderable.contains(GetPackageHash(package.m_unvalidated_txns))) {
+        // Should we do anything else here?
+        return;
+    }
+    const auto package_result{ProcessNewPackage(m_chainman.ActiveChainstate(), m_mempool,
+                                                package.m_unvalidated_txns, /*test_accept=*/false)};
+    if (package_result.m_state.IsInvalid()) {
+        // If another peer sends the same packageinfo again, we can immediately reject it without
+        // re-downloading the transactions. Note that state.IsInvalid() doesn't mean all
+        // transactions have been rejected.
+        m_recent_rejects_reconsiderable.insert(package.m_pkginfo_hash);
+    }
+    std::set<uint256> successful_txns;
+    std::set<uint256> invalid_final_txns;
+    for (const auto& tx : package.m_unvalidated_txns) {
+        const auto& txid = tx->GetHash();
+        const auto& wtxid = tx->GetWitnessHash();
+        const auto result{package_result.m_tx_results.find(wtxid)};
+        if (package_result.m_state.IsValid() ||
+            package_result.m_state.GetResult() == PackageValidationResult::PCKG_TX) {
+            // If PCKG_TX or valid, every tx should have a result.
+            Assume(result != package_result.m_tx_results.end());
+        }
+        if (result == package_result.m_tx_results.end()) break;
+        if (result->second.m_result_type == MempoolAcceptResult::ResultType::VALID) {
+            LogPrint(BCLog::MEMPOOL, "\nProcessPackage: tx %s from peer=%d accepted\n", txid.ToString(), node.GetId());
+            successful_txns.insert(wtxid);
+            m_txrequest.ForgetTxHash(txid);
+            m_txrequest.ForgetTxHash(wtxid);
+            RelayTransaction(txid, wtxid);
+            node.m_last_tx_time = GetTime<std::chrono::seconds>();
+            for (const CTransactionRef& removedTx : result->second.m_replaced_transactions.value()) {
+                AddToCompactExtraTransactions(removedTx);
+            }
+        } else if (result->second.m_state.GetResult() != TxValidationResult::TX_WITNESS_STRIPPED) {
+            if (result->second.m_state.GetResult() == TxValidationResult::TX_LOW_FEE) {
+                m_recent_rejects_reconsiderable.insert(wtxid);
+                // FIXME: also cache subpackage failure
+            } else {
+                m_recent_rejects.insert(wtxid);
+                if (result->second.m_state.GetResult() == TxValidationResult::TX_INPUTS_NOT_STANDARD && wtxid != txid) {
+                    m_recent_rejects.insert(txid);
+                    m_txrequest.ForgetTxHash(txid);
+                } else if (result->second.m_state.GetResult() == TxValidationResult::TX_CONSENSUS) {
+                    invalid_final_txns.insert(wtxid);
+                }
+            }
+            m_txrequest.ForgetTxHash(wtxid);
+            if (RecursiveDynamicUsage(*tx) < 100000) {
+                AddToCompactExtraTransactions(tx);
+            }
+            LogPrint(BCLog::MEMPOOLREJ, "\nProcessPackage: %s from peer=%d was not accepted: %s\n",
+                     wtxid.ToString(), node.GetId(), result->second.m_state.ToString());
+            MaybePunishNodeForTx(wtxid == package.m_rep_wtxid ? node.GetId() : package.m_info_provider, result->second.m_state);
+        }
+        m_txpackagetracker->EraseOrphanTx(wtxid);
+    }
+    m_txpackagetracker->FinalizeTransactions(successful_txns, invalid_final_txns);
+    // Do this last to avoid adding children that were already validated within this package.
+    for (const auto& tx : package.m_unvalidated_txns) {
+        auto iter{package_result.m_tx_results.find(tx->GetWitnessHash())};
+        if (iter != package_result.m_tx_results.end() && iter->second.m_result_type == MempoolAcceptResult::ResultType::VALID) {
+            m_txpackagetracker->AddChildrenToWorkSet(*tx);
+        }
+    }
+}
+
 bool PeerManagerImpl::PrepareBlockFilterRequest(CNode& node, Peer& peer,
                                                 BlockFilterType filter_type, uint32_t start_height,
                                                 const uint256& stop_hash, uint32_t max_height_diff,
@@ -4903,7 +4979,26 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
     }
 
     if (msg_type == NetMsgType::PKGTXNS) {
-        LogPrint(BCLog::NET, "pkgtxns received from peer=%d", pfrom.GetId());
+        if (RejectIncomingTxs(pfrom)) {
+            LogPrint(BCLog::NET, "\npkgtxns sent in violation of protocol peer=%d\n", pfrom.GetId());
+            pfrom.fDisconnect = true;
+            return;
+        }
+        if (!m_txpackagetracker) return;
+        unsigned int num_txns = ReadCompactSize(vRecv);
+        if (num_txns == 0) return;
+        if (num_txns > MAX_PACKAGE_COUNT) {
+            Misbehaving(*peer, 100, strprintf("pkgtxns size = %u", num_txns));
+            return;
+        }
+        std::vector<CTransactionRef> package_txns;
+        package_txns.resize(num_txns);
+        for (unsigned int n = 0; n < num_txns; n++) {
+            vRecv >> package_txns[n];
+        }
+        if (const auto package_to_validate{m_txpackagetracker->ReceivedPkgTxns(pfrom.GetId(), package_txns)}) {
+            ProcessPackage(pfrom, package_to_validate.value());
+        }
         return;
     }
 
@@ -5098,6 +5193,8 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                         pfrom.fDisconnect = true;
                     }
                     m_txpackagetracker->ForgetPkgInfo(pfrom.GetId(), inv.hash, node::RECEIVER_INIT_ANCESTOR_PACKAGES);
+                } else if (inv.IsMsgPkgTxns() && m_enable_package_relay) {
+                    m_txpackagetracker->ReceivedNotFound(pfrom.GetId(), inv.hash);
                 }
             }
         }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1479,6 +1479,7 @@ void PeerManagerImpl::AddOrphanAnnouncer(NodeId nodeid, const uint256& orphan_wt
     // - "preferred": if fPreferredDownload is set (= outbound, or NetPermissionFlags::NoBan permission)
     // - "reqtime": current time plus delays for:
     //   - NONPREF_PEER_TX_DELAY for announcements from non-preferred connections
+    //   - TXID_RELAY_DELAY for txid-based parent requests while package relay peers are available
     //   - OVERLOADED_PEER_TX_DELAY for announcements from peers which have at least
     //     MAX_PEER_TX_REQUEST_IN_FLIGHT requests in flight
     //     TODO: allow peers with Relay permissions to bypass this restiction
@@ -1486,6 +1487,9 @@ void PeerManagerImpl::AddOrphanAnnouncer(NodeId nodeid, const uint256& orphan_wt
     const bool preferred = state->fPreferredDownload;
     if (!preferred) delay += NONPREF_PEER_TX_DELAY;
     const bool overloaded = m_txrequest.CountInFlight(nodeid) >= MAX_PEER_TX_REQUEST_IN_FLIGHT;
+    const auto peer_ref{GetPeerRef(nodeid)};
+    if (!peer_ref) return;
+    if (!peer_ref->m_package_relay && m_package_relay_peers > 0) delay += TXID_RELAY_DELAY;
     if (overloaded) delay += OVERLOADED_PEER_TX_DELAY;
     m_txpackagetracker->AddOrphanTx(nodeid, orphan_wtxid, tx, preferred, current_time + delay);
 }
@@ -4162,6 +4166,58 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         return;
     }
 
+    if (msg_type == NetMsgType::ANCPKGINFO) {
+        std::vector<uint256> package_wtxids;
+        vRecv >> package_wtxids;
+        if (package_wtxids.empty()) return;
+        if (!peer->m_package_relay) {
+            LogPrint(BCLog::NET, "ancpkginfo sent in violation of protocol, disconnecting peer=%d\n", pfrom.GetId());
+            pfrom.fDisconnect = true;
+            return;
+        }
+        if (!m_txpackagetracker->PkgInfoAllowed(pfrom.GetId(), package_wtxids.back(), node::RECEIVER_INIT_ANCESTOR_PACKAGES)) {
+            LogPrint(BCLog::NET, "unsolicited ancpkginfo sent, disconnecting peer=%d\n", pfrom.GetId());
+            pfrom.fDisconnect = true;
+            return;
+        }
+
+        const auto& rep_wtxid{package_wtxids.back()};
+        if (package_wtxids.size() > MAX_PACKAGE_COUNT) {
+            LogPrint(BCLog::NET, "discarding package info for tx %s, too many transactions\n", rep_wtxid.ToString());
+            // FIXME: disconnect?
+            m_txpackagetracker->ForgetPkgInfo(pfrom.GetId(), package_wtxids.back(), node::RECEIVER_INIT_ANCESTOR_PACKAGES);
+            return;
+        }
+        LOCK(::cs_main);
+        if (m_chainman.ActiveChainstate().IsInitialBlockDownload()) return;
+        // We have already validated this exact set of transactions recently, so don't do it again.
+        if (m_recent_rejects_reconsiderable.contains(GetCombinedHash(package_wtxids))) {
+            LogPrint(BCLog::NET, "discarding package info for tx %s, this package has already been rejected\n",
+                     rep_wtxid.ToString());
+            m_txpackagetracker->ForgetPkgInfo(pfrom.GetId(), package_wtxids.back(), node::RECEIVER_INIT_ANCESTOR_PACKAGES);
+            return;
+        }
+        for (const auto& wtxid : package_wtxids) {
+            // If a transaction is in m_recent_rejects and not m_recent_rejects_reconsiderable, that
+            // means it will not become valid by adding another transaction.
+            if (m_recent_rejects.contains(wtxid)) {
+                LogPrint(BCLog::NET,
+                         "discarding package for tx %s, tx %s has already been rejected and is not eligible for reconsideration\n",
+                         rep_wtxid.ToString(), wtxid.ToString());
+                m_txpackagetracker->ForgetPkgInfo(pfrom.GetId(), package_wtxids.back(), node::RECEIVER_INIT_ANCESTOR_PACKAGES);
+                return;
+            }
+        }
+        // For now, just add these transactions as announcements.
+        const auto current_time{GetTime<std::chrono::microseconds>()};
+        for (const auto& wtxid : package_wtxids) {
+            AddKnownTx(*peer, wtxid);
+            if (!AlreadyHaveTx(GenTxid::Wtxid(wtxid)) && !m_chainman.ActiveChainstate().IsInitialBlockDownload()) {
+                AddTxAnnouncement(pfrom, GenTxid::Wtxid(wtxid), current_time);
+            }
+        }
+    }
+
     if (msg_type == NetMsgType::TX) {
         if (RejectIncomingTxs(pfrom)) {
             LogPrint(BCLog::NET, "transaction sent in violation of protocol peer=%d\n", pfrom.GetId());
@@ -4978,6 +5034,13 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                     // If we receive a NOTFOUND message for a tx we requested, mark the announcement for it as
                     // completed in TxRequestTracker.
                     m_txrequest.ReceivedResponse(pfrom.GetId(), inv.hash);
+                } else if (inv.IsMsgAncPkgInfo() && m_enable_package_relay) {
+                    if (!m_txpackagetracker->PkgInfoAllowed(pfrom.GetId(), inv.hash, node::RECEIVER_INIT_ANCESTOR_PACKAGES)) {
+                        LogPrint(BCLog::NET, "\nUnsolicited ancpkginfo sent, disconnecting peer=%d\n", pfrom.GetId());
+                        // Unsolicited ancpkginfo or peer is not registered for package relay.
+                        pfrom.fDisconnect = true;
+                    }
+                    m_txpackagetracker->ForgetPkgInfo(pfrom.GetId(), inv.hash, node::RECEIVER_INIT_ANCESTOR_PACKAGES);
                 }
             }
         }
@@ -6017,7 +6080,7 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
             if (AlreadyHaveTx(gtxid, /*include_orphanage=*/false)) {
                 m_txpackagetracker->FinalizeTransactions({gtxid.GetHash()}, {});
             } else {
-                vGetData.emplace_back(MSG_TX | GetFetchFlags(*peer), gtxid.GetHash());
+                vGetData.emplace_back(gtxid.IsWtxid() ? MSG_ANCPKGINFO : (MSG_TX | GetFetchFlags(*peer)), gtxid.GetHash());
                 if (vGetData.size() >= MAX_GETDATA_SZ) {
                     m_connman.PushMessage(pto, msgMaker.Make(NetMsgType::GETDATA, vGetData));
                     vGetData.clear();

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -36,7 +36,6 @@
 #include <timedata.h>
 #include <tinyformat.h>
 #include <txmempool.h>
-#include <txorphanage.h>
 #include <txrequest.h>
 #include <util/check.h> // For NDEBUG compile time check
 #include <util/strencodings.h>
@@ -936,9 +935,6 @@ private:
     /** Number of peers from which we're downloading blocks. */
     int m_peers_downloading_from GUARDED_BY(cs_main) = 0;
 
-    /** Storage for orphan information */
-    TxOrphanage m_orphanage;
-
     void AddToCompactExtraTransactions(const CTransactionRef& tx) EXCLUSIVE_LOCKS_REQUIRED(g_msgproc_mutex);
 
     /** Orphan/conflicted/etc transactions that are kept for compact block reconstruction.
@@ -1510,7 +1506,7 @@ void PeerManagerImpl::FinalizeNode(const CNode& node)
     for (const QueuedBlock& entry : state->vBlocksInFlight) {
         mapBlocksInFlight.erase(entry.pindex->GetBlockHash());
     }
-    m_orphanage.EraseForPeer(nodeid);
+    m_txpackagetracker->DisconnectedPeer(nodeid);
     m_txrequest.DisconnectedPeer(nodeid);
     if (m_txreconciliation) m_txreconciliation->ForgetPeer(nodeid);
     m_num_preferred_download_peers -= state->fPreferredDownload;
@@ -1529,7 +1525,7 @@ void PeerManagerImpl::FinalizeNode(const CNode& node)
         assert(m_outbound_peers_with_protect_from_disconnect == 0);
         assert(m_wtxid_relay_peers == 0);
         assert(m_txrequest.Size() == 0);
-        assert(m_orphanage.Size() == 0);
+        assert(m_txpackagetracker->OrphanageSize() == 0);
     }
     } // cs_main
     if (node.fSuccessfullyConnected && misbehavior == 0 &&
@@ -1828,7 +1824,7 @@ void PeerManagerImpl::StartScheduledTasks(CScheduler& scheduler)
  */
 void PeerManagerImpl::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex)
 {
-    m_orphanage.EraseForBlock(*pblock);
+    m_txpackagetracker->BlockConnected(*pblock);
     m_last_tip_update = GetTime<std::chrono::seconds>();
 
     {
@@ -2015,7 +2011,7 @@ bool PeerManagerImpl::AlreadyHaveTx(const GenTxid& gtxid)
 
     const uint256& hash = gtxid.GetHash();
 
-    if (m_orphanage.HaveTx(gtxid)) return true;
+    if (m_txpackagetracker->OrphanageHaveTx(gtxid)) return true;
 
     {
         LOCK(m_recent_confirmed_transactions_mutex);
@@ -2920,7 +2916,7 @@ bool PeerManagerImpl::ProcessOrphanTx(Peer& peer)
 
     CTransactionRef porphanTx = nullptr;
 
-    while (CTransactionRef porphanTx = m_orphanage.GetTxToReconsider(peer.m_id)) {
+    while (CTransactionRef porphanTx = m_txpackagetracker->GetTxToReconsider(peer.m_id)) {
         const MempoolAcceptResult result = m_chainman.ProcessTransaction(porphanTx);
         const TxValidationState& state = result.m_state;
         const uint256& orphanHash = porphanTx->GetHash();
@@ -2928,8 +2924,8 @@ bool PeerManagerImpl::ProcessOrphanTx(Peer& peer)
         if (result.m_result_type == MempoolAcceptResult::ResultType::VALID) {
             LogPrint(BCLog::MEMPOOL, "   accepted orphan tx %s\n", orphanHash.ToString());
             RelayTransaction(orphanHash, porphanTx->GetWitnessHash());
-            m_orphanage.AddChildrenToWorkSet(*porphanTx);
-            m_orphanage.EraseTx(orphanHash);
+            m_txpackagetracker->AddChildrenToWorkSet(*porphanTx);
+            m_txpackagetracker->EraseOrphanTx(orphanHash);
             for (const CTransactionRef& removedTx : result.m_replaced_transactions.value()) {
                 AddToCompactExtraTransactions(removedTx);
             }
@@ -2975,7 +2971,7 @@ bool PeerManagerImpl::ProcessOrphanTx(Peer& peer)
                     m_recent_rejects.insert(porphanTx->GetHash());
                 }
             }
-            m_orphanage.EraseTx(orphanHash);
+            m_txpackagetracker->EraseOrphanTx(orphanHash);
             return true;
         }
     }
@@ -4051,7 +4047,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             m_txrequest.ForgetTxHash(tx.GetHash());
             m_txrequest.ForgetTxHash(tx.GetWitnessHash());
             RelayTransaction(tx.GetHash(), tx.GetWitnessHash());
-            m_orphanage.AddChildrenToWorkSet(tx);
+            m_txpackagetracker->AddChildrenToWorkSet(tx);
 
             pfrom.m_last_tx_time = GetTime<std::chrono::seconds>();
 
@@ -4098,7 +4094,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                     if (!AlreadyHaveTx(gtxid)) AddTxAnnouncement(pfrom, gtxid, current_time);
                 }
 
-                if (m_orphanage.AddTx(ptx, pfrom.GetId())) {
+                if (m_txpackagetracker->OrphanageAddTx(ptx, pfrom.GetId())) {
                     AddToCompactExtraTransactions(ptx);
                 }
 
@@ -4108,7 +4104,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
                 // DoS prevention: do not allow m_orphanage to grow unbounded (see CVE-2012-3789)
                 unsigned int nMaxOrphanTx = (unsigned int)std::max((int64_t)0, gArgs.GetIntArg("-maxorphantx", DEFAULT_MAX_ORPHAN_TRANSACTIONS));
-                m_orphanage.LimitOrphans(nMaxOrphanTx);
+                m_txpackagetracker->LimitOrphans(nMaxOrphanTx);
             } else {
                 LogPrint(BCLog::MEMPOOL, "not keeping orphan with rejected parents %s\n",tx.GetHash().ToString());
                 // We will continue to reject this tx since it has rejected
@@ -4928,7 +4924,7 @@ bool PeerManagerImpl::ProcessMessages(CNode* pfrom, std::atomic<bool>& interrupt
         //  by another peer that was already processed; in that case,
         //  the extra work may not be noticed, possibly resulting in an
         //  unnecessary 100ms delay)
-        if (m_orphanage.HaveTxToReconsider(peer->m_id)) fMoreWork = true;
+        if (m_txpackagetracker->HaveTxToReconsider(peer->m_id)) fMoreWork = true;
     } catch (const std::exception& e) {
         LogPrint(BCLog::NET, "%s(%s, %u bytes): Exception '%s' (%s) caught\n", __func__, SanitizeString(msg.m_type), msg.m_message_size, e.what(), typeid(e).name());
     } catch (...) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -960,6 +960,10 @@ private:
     CTransactionRef FindTxForGetData(const Peer::TxRelay& tx_relay, const GenTxid& gtxid, const std::chrono::seconds mempool_req, const std::chrono::seconds now)
         EXCLUSIVE_LOCKS_REQUIRED(NetEventsInterface::g_msgproc_mutex);
 
+    /** Get AncPkgInfo for a transaction. Returns std::nullopt if something is wrong and the
+     * node should be disconnected. */
+    std::optional<std::vector<uint256>> MaybeGetAncPkgInfo(Peer& peer, const CTransactionRef& tx);
+
     void ProcessGetData(CNode& pfrom, Peer& peer, const std::atomic<bool>& interruptMsgProc)
         EXCLUSIVE_LOCKS_REQUIRED(!m_most_recent_block_mutex, peer.m_getdata_requests_mutex, NetEventsInterface::g_msgproc_mutex)
         LOCKS_EXCLUDED(::cs_main);
@@ -2382,6 +2386,31 @@ CTransactionRef PeerManagerImpl::FindTxForGetData(const Peer::TxRelay& tx_relay,
     return {};
 }
 
+std::optional<std::vector<uint256>> PeerManagerImpl::MaybeGetAncPkgInfo(Peer& peer, const CTransactionRef& tx)
+{
+    if (!peer.m_package_relay) {
+        return std::nullopt;
+    }
+    CTxMemPool::setEntries ancestors;
+    {
+        LOCK(m_mempool.cs);
+        auto txiter{m_mempool.GetIter(tx->GetHash())};
+        if (txiter == std::nullopt) {
+            // This tx is no longer in mempool (maybe in mapRelay)
+            return std::vector<uint256>({});
+        }
+        ancestors = m_mempool.AssumeCalculateMemPoolAncestors(__func__, **txiter, CTxMemPool::Limits::NoLimits(), /*fSearchForParents=*/false);
+        // Otherwise the transaction will appear multiple times in the wtxids list.
+        Assume(ancestors.count(txiter.value()) == 0);
+    }
+    std::vector<uint256> ancestor_package_wtxids;
+    std::transform(ancestors.cbegin(), ancestors.cend(), std::back_inserter(ancestor_package_wtxids),
+        [](const auto& entry){return entry->GetTx().GetWitnessHash();});
+    // Last wtxid is the representative tx, even if it has no unconfirmed ancestors.
+    ancestor_package_wtxids.push_back(tx->GetWitnessHash());
+    return ancestor_package_wtxids;
+}
+
 void PeerManagerImpl::ProcessGetData(CNode& pfrom, Peer& peer, const std::atomic<bool>& interruptMsgProc)
 {
     AssertLockNotHeld(cs_main);
@@ -2399,7 +2428,7 @@ void PeerManagerImpl::ProcessGetData(CNode& pfrom, Peer& peer, const std::atomic
     // Process as many TX items from the front of the getdata queue as
     // possible, since they're common and it's efficient to batch process
     // them.
-    while (it != peer.m_getdata_requests.end() && it->IsGenTxMsg()) {
+    while (it != peer.m_getdata_requests.end() && (it->IsGenTxMsg() || it->IsMsgAncPkgInfo())) {
         if (interruptMsgProc) return;
         // The send buffer provides backpressure. If there's no space in
         // the buffer, pause processing until the next call.
@@ -2415,9 +2444,24 @@ void PeerManagerImpl::ProcessGetData(CNode& pfrom, Peer& peer, const std::atomic
 
         CTransactionRef tx = FindTxForGetData(*tx_relay, ToGenTxid(inv), mempool_req, now);
         if (tx) {
-            // WTX and WITNESS_TX imply we serialize with witness
-            int nSendFlags = (inv.IsMsgTx() ? SERIALIZE_TRANSACTION_NO_WITNESS : 0);
-            m_connman.PushMessage(&pfrom, msgMaker.Make(nSendFlags, NetMsgType::TX, *tx));
+            if (inv.IsGenTxMsg()) {
+                // WTX and WITNESS_TX imply we serialize with witness
+                int nSendFlags = (inv.IsMsgTx() ? SERIALIZE_TRANSACTION_NO_WITNESS : 0);
+                m_connman.PushMessage(&pfrom, msgMaker.Make(nSendFlags, NetMsgType::TX, *tx));
+            } else if (inv.IsMsgAncPkgInfo()) {
+                auto ancestor_wtxids = MaybeGetAncPkgInfo(peer, tx);
+                if (ancestor_wtxids == std::nullopt) {
+                    pfrom.fDisconnect = true;
+                    // No need to process the other requests if we are disconnecting the peer.
+                    LogPrint(BCLog::NET, "\nDisconnecting peer %d -- requested ancpkginfo but not allowed\n", pfrom.GetId());
+                    return;
+                } else if (ancestor_wtxids->empty()) {
+                    // Couldn't create the ancpkginfo for some reason, send a notfound.
+                    vNotFound.push_back(inv);
+                    continue;
+                }
+                m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::ANCPKGINFO, ancestor_wtxids.value()));
+            }
             m_mempool.RemoveUnbroadcastTx(tx->GetHash());
             // As we're going to send tx, make sure its unconfirmed parents are made requestable.
             std::vector<uint256> parent_ids_to_add;
@@ -2430,6 +2474,7 @@ void PeerManagerImpl::ProcessGetData(CNode& pfrom, Peer& peer, const std::atomic
                     for (const CTxMemPoolEntry& parent : parents) {
                         if (parent.GetTime() > now - UNCONDITIONAL_RELAY_DELAY) {
                             parent_ids_to_add.push_back(parent.GetTx().GetHash());
+                            parent_ids_to_add.push_back(parent.GetTx().GetWitnessHash());
                         }
                     }
                 }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -680,9 +680,14 @@ private:
     void AddTxAnnouncement(const CNode& node, const GenTxid& gtxid, std::chrono::microseconds current_time)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
+    /** Helper function for AddOrphanResolutionCandidates, but can also be called by itself if the
+     * orphan is announced again later. */
+    void AddOrphanAnnouncer(NodeId nodeid, const uint256& orphan_wtxid, const CTransactionRef& tx, std::chrono::microseconds current_time)
+        EXCLUSIVE_LOCKS_REQUIRED(::cs_main, !m_peer_mutex);
+
     /** Register with orphan TxRequestTracker that a peer may help us resolve this orphan. */
-    void AddOrphanResolutionCandidate(NodeId nodeid, const uint256& orphan_wtxid, const CTransactionRef& tx, std::chrono::microseconds current_time)
-        EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    void AddOrphanResolutionCandidates(const CTransactionRef& orphan, NodeId originator)
+        EXCLUSIVE_LOCKS_REQUIRED(::cs_main, !m_peer_mutex);
 
     /** Send a version message to a peer */
     void PushNodeVersion(CNode& pnode, const Peer& peer);
@@ -1411,16 +1416,47 @@ void PeerManagerImpl::PushNodeVersion(CNode& pnode, const Peer& peer)
     }
 }
 
-void PeerManagerImpl::AddOrphanResolutionCandidate(NodeId nodeid, const uint256& orphan_wtxid, const CTransactionRef& orphan, std::chrono::microseconds current_time)
+void PeerManagerImpl::AddOrphanAnnouncer(NodeId nodeid, const uint256& orphan_wtxid, const CTransactionRef& tx, std::chrono::microseconds current_time)
 {
-    AssertLockHeld(::cs_main);
+    AssertLockHeld(::cs_main); // For m_txrequest
+    const bool connected = m_connman.ForNode(nodeid, [](CNode* node) { return node->fSuccessfullyConnected && !node->fDisconnect; });
+    if (!connected) return;
+    if (m_txpackagetracker->Count(nodeid) + m_txrequest.Count(nodeid) >= MAX_PEER_TX_ANNOUNCEMENTS) {
+        // Too many queued announcements. Request from a different peer.
+        // TODO: Allow peers with Relay permissions to bypass this restriction.
+        return;
+    }
     const CNodeState* state = State(nodeid);
-    // Decide the TxRequestTracker parameters for this orphan resolution:
+    // Decide the TxRequestTracker parameters for this orphan resolution.
+    // TxPackageTracker may also increase the delay.
     // - "preferred": if fPreferredDownload is set (= outbound, or NetPermissionFlags::NoBan permission)
-    // - "reqtime": current time
+    // - "reqtime": current time plus delays for:
+    //   - NONPREF_PEER_TX_DELAY for announcements from non-preferred connections
+    //   - OVERLOADED_PEER_TX_DELAY for announcements from peers which have at least
+    //     MAX_PEER_TX_REQUEST_IN_FLIGHT requests in flight
+    //     TODO: allow peers with Relay permissions to bypass this restiction
     auto delay{0us};
     const bool preferred = state->fPreferredDownload;
-    m_txpackagetracker->AddOrphanTx(nodeid, orphan_wtxid, orphan, preferred, current_time + delay);
+    if (!preferred) delay += NONPREF_PEER_TX_DELAY;
+    const bool overloaded = m_txrequest.CountInFlight(nodeid) >= MAX_PEER_TX_REQUEST_IN_FLIGHT;
+    if (overloaded) delay += OVERLOADED_PEER_TX_DELAY;
+    m_txpackagetracker->AddOrphanTx(nodeid, orphan_wtxid, tx, preferred, current_time + delay);
+}
+void PeerManagerImpl::AddOrphanResolutionCandidates(const CTransactionRef& orphan, NodeId originator)
+{
+    const auto current_time{GetTime<std::chrono::microseconds>()};
+
+    // The originator will not show up in GetCandidatePeers() since we already requested from them.
+    AddOrphanAnnouncer(originator, orphan->GetWitnessHash(), orphan, current_time);
+    // We prefer to request the orphan's ancestors via package relay rather than txids
+    // of missing inputs. Also, if the first request fails, we should try again.
+    // Get all peers that announced this transaction and prioritize accordingly...
+    for (const auto nodeid : m_txrequest.GetCandidatePeers(orphan->GetWitnessHash())) {
+        AddOrphanAnnouncer(nodeid, orphan->GetWitnessHash(), orphan, current_time);
+    }
+    for (const auto nodeid : m_txrequest.GetCandidatePeers(orphan->GetHash())) {
+        AddOrphanAnnouncer(nodeid, orphan->GetWitnessHash(), orphan, current_time);
+    }
 }
 
 void PeerManagerImpl::AddTxAnnouncement(const CNode& node, const GenTxid& gtxid, std::chrono::microseconds current_time)
@@ -3733,6 +3769,9 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                 if (!fAlreadyHave && !m_chainman.ActiveChainstate().IsInitialBlockDownload()) {
                     AddTxAnnouncement(pfrom, gtxid, current_time);
                 }
+                if (inv.IsMsgWtx() && m_txpackagetracker->OrphanageHaveTx(gtxid) && !m_chainman.ActiveChainstate().IsInitialBlockDownload()) {
+                    AddOrphanAnnouncer(pfrom.GetId(), inv.hash, nullptr, current_time);
+                }
             } else {
                 LogPrint(BCLog::NET, "Unknown inv type \"%s\" received from peer=%d\n", inv.ToString(), pfrom.GetId());
             }
@@ -4090,9 +4129,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
             }
             if (!fRejectedParents) {
                 const bool had_before{m_txpackagetracker->OrphanageHaveTx(GenTxid::Wtxid(ptx->GetWitnessHash()))};
-                const auto current_time{GetTime<std::chrono::microseconds>()};
-                AddOrphanResolutionCandidate(pfrom.GetId(), ptx->GetWitnessHash(), ptx, current_time);
-
+                AddOrphanResolutionCandidates(ptx, pfrom.GetId());
                 if (!had_before && m_txpackagetracker->OrphanageHaveTx(GenTxid::Wtxid(ptx->GetWitnessHash()))) {
                     AddToCompactExtraTransactions(ptx);
                 }
@@ -5815,7 +5852,7 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
         }
 
         //
-        // Message: getdata (transactions)
+        // Message: getdata (transactions and ancpkginfo)
         //
         std::vector<std::pair<NodeId, GenTxid>> expired;
         auto requestable = m_txrequest.GetRequestable(pto->GetId(), current_time, &expired);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -6070,6 +6070,13 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
                         // Peer told you to not send transactions at that feerate? Don't bother sending it.
                         if (txinfo.fee < filterrate.GetFee(txinfo.vsize)) {
                             continue;
+                        } else if (!peer->m_package_relay) {
+                            // If any of the parents are below the fee filter and the peer doesn't
+                            // support package relay, they probably won't accept this transaction.
+                            // Save older peers' bandwidth by skipping this transaction.
+                            if (auto min_parent_feerate{m_mempool.MinimumFeerateWithParents(ToGenTxid(inv))}) {
+                                if (min_parent_feerate.value() < filterrate) continue;
+                            }
                         }
                         if (tx_relay->m_bloom_filter && !tx_relay->m_bloom_filter->IsRelevantAndUpdate(*txinfo.tx)) continue;
                         // Send

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2925,7 +2925,7 @@ bool PeerManagerImpl::ProcessOrphanTx(Peer& peer)
             LogPrint(BCLog::MEMPOOL, "   accepted orphan tx %s\n", orphanHash.ToString());
             RelayTransaction(orphanHash, porphanTx->GetWitnessHash());
             m_txpackagetracker->AddChildrenToWorkSet(*porphanTx);
-            m_txpackagetracker->EraseOrphanTx(orphanHash);
+            m_txpackagetracker->EraseOrphanTx(porphanTx->GetWitnessHash());
             for (const CTransactionRef& removedTx : result.m_replaced_transactions.value()) {
                 AddToCompactExtraTransactions(removedTx);
             }
@@ -2971,7 +2971,7 @@ bool PeerManagerImpl::ProcessOrphanTx(Peer& peer)
                     m_recent_rejects.insert(porphanTx->GetHash());
                 }
             }
-            m_txpackagetracker->EraseOrphanTx(orphanHash);
+            m_txpackagetracker->EraseOrphanTx(porphanTx->GetWitnessHash());
             return true;
         }
     }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1666,6 +1666,7 @@ bool PeerManagerImpl::GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) c
         stats.m_fee_filter_received = 0;
     }
 
+    stats.m_package_relay = peer->m_package_relay;
     stats.m_ping_wait = ping_wait;
     stats.m_addr_processed = peer->m_addr_processed.load();
     stats.m_addr_rate_limited = peer->m_addr_rate_limited.load();

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -21,6 +21,7 @@
 #include <netbase.h>
 #include <netmessagemaker.h>
 #include <node/blockstorage.h>
+#include <node/txpackagetracker.h>
 #include <node/txreconciliation.h>
 #include <policy/fees.h>
 #include <policy/policy.h>
@@ -716,6 +717,7 @@ private:
     CTxMemPool& m_mempool;
     TxRequestTracker m_txrequest GUARDED_BY(::cs_main);
     std::unique_ptr<TxReconciliationTracker> m_txreconciliation;
+    std::unique_ptr<node::TxPackageTracker> m_txpackagetracker;
 
     /** The height of the best chain */
     std::atomic<int> m_best_height{-1};
@@ -1801,6 +1803,7 @@ PeerManagerImpl::PeerManagerImpl(CConnman& connman, AddrMan& addrman,
     if (gArgs.GetBoolArg("-txreconciliation", DEFAULT_TXRECONCILIATION_ENABLE)) {
         m_txreconciliation = std::make_unique<TxReconciliationTracker>(TXRECONCILIATION_VERSION);
     }
+    m_txpackagetracker = std::make_unique<node::TxPackageTracker>();
 }
 
 void PeerManagerImpl::StartScheduledTasks(CScheduler& scheduler)

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -30,6 +30,7 @@ struct CNodeStateStats {
     std::chrono::microseconds m_ping_wait;
     std::vector<int> vHeightInFlight;
     bool m_relay_txs;
+    bool m_package_relay;
     CAmount m_fee_filter_received;
     uint64_t m_addr_processed = 0;
     uint64_t m_addr_rate_limited = 0;

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -43,7 +43,8 @@ class PeerManager : public CValidationInterface, public NetEventsInterface
 public:
     static std::unique_ptr<PeerManager> make(CConnman& connman, AddrMan& addrman,
                                              BanMan* banman, ChainstateManager& chainman,
-                                             CTxMemPool& pool, bool ignore_incoming_txs);
+                                             CTxMemPool& pool, bool ignore_incoming_txs,
+                                             bool enable_package_relay);
     virtual ~PeerManager() { }
 
     /**

--- a/src/node/txpackagetracker.cpp
+++ b/src/node/txpackagetracker.cpp
@@ -4,12 +4,33 @@
 
 #include <node/txpackagetracker.h>
 
+#include <common/bloom.h>
+#include <logging.h>
 #include <txorphanage.h>
+#include <txrequest.h>
+#include <util/hasher.h>
 
 namespace node {
+    /** How long to wait before requesting orphan ancpkginfo/parents from an additional peer.
+     * Same as GETDATA_TX_INTERVAL. */
+    static constexpr auto ORPHAN_ANCESTOR_GETDATA_INTERVAL{60s};
+
+    /** Delay to add if an orphan resolution candidate is already using a lot of memory in the
+     * orphanage. */
+    static constexpr auto ORPHANAGE_OVERLOAD_DELAY{2s};
+
 class TxPackageTracker::Impl {
     /** Manages unvalidated tx data (orphan transactions for which we are downloading ancestors). */
     TxOrphanage m_orphanage;
+
+    mutable Mutex m_mutex;
+
+    /** Tracks orphans for which we need to request ancestor information. All hashes stored are
+     * wtxids, i.e., the wtxid of the orphan. However, the is_wtxid field is used to indicate
+     * whether we would request the ancestor information by wtxid (via package relay) or by txid
+     * (via prevouts of the missing inputs). */
+    TxRequestTracker orphan_request_tracker GUARDED_BY(m_mutex);
+
 public:
     Impl() = default;
 
@@ -18,14 +39,122 @@ public:
     bool OrphanageHaveTx(const GenTxid& gtxid) { return m_orphanage.HaveTx(gtxid); }
     CTransactionRef GetTxToReconsider(NodeId peer) { return m_orphanage.GetTxToReconsider(peer); }
     int EraseOrphanTx(const uint256& txid) { return m_orphanage.EraseTx(txid); }
-    void DisconnectedPeer(NodeId peer) {
-        m_orphanage.EraseForPeer(peer);
+    void DisconnectedPeer(NodeId nodeid) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        LOCK(m_mutex);
+        orphan_request_tracker.DisconnectedPeer(nodeid);
+        m_orphanage.EraseForPeer(nodeid);
     }
-    void BlockConnected(const CBlock& block) { m_orphanage.EraseForBlock(block); }
+    void BlockConnected(const CBlock& block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        const auto wtxids_erased{m_orphanage.EraseForBlock(block)};
+        std::set<uint256> block_wtxids;
+        std::set<uint256> conflicted_wtxids;
+        for (const CTransactionRef& ptx : block.vtx) {
+            block_wtxids.insert(ptx->GetWitnessHash());
+        }
+        for (const auto& wtxid : wtxids_erased) {
+            if (block_wtxids.count(wtxid) == 0) {
+                conflicted_wtxids.insert(wtxid);
+            }
+        }
+        FinalizeTransactions(block_wtxids, conflicted_wtxids);
+    }
     void LimitOrphans(unsigned int max_orphans) { m_orphanage.LimitOrphans(max_orphans); }
     void AddChildrenToWorkSet(const CTransaction& tx) { m_orphanage.AddChildrenToWorkSet(tx); }
     bool HaveTxToReconsider(NodeId peer) { return m_orphanage.HaveTxToReconsider(peer); }
     size_t OrphanageSize() { return m_orphanage.Size(); }
+    void AddOrphanTx(NodeId nodeid, const uint256& wtxid, const CTransactionRef& tx, bool is_preferred, std::chrono::microseconds reqtime)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        LOCK(m_mutex);
+        // Skip if we weren't provided the tx and can't find the wtxid in the orphanage.
+        if (tx == nullptr && !m_orphanage.HaveTx(GenTxid::Wtxid(wtxid))) return;
+
+        // Add delay to the reqtime if this peer is already using a lot of orphanage space.
+        if (m_orphanage.IsOverloaded(nodeid)) reqtime += ORPHANAGE_OVERLOAD_DELAY;
+
+        // Even though this stores the orphan wtxid, is_wtxid=false because we will be requesting the parents via txid.
+        orphan_request_tracker.ReceivedInv(nodeid, GenTxid::Txid(wtxid), is_preferred, reqtime);
+
+        if (tx != nullptr) {
+            m_orphanage.AddTx(tx, nodeid);
+        } else {
+            m_orphanage.AddTx(m_orphanage.GetTx(wtxid), nodeid);
+        }
+    }
+    size_t CountInFlight(NodeId nodeid) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        LOCK(m_mutex);
+        auto count{orphan_request_tracker.CountInFlight(nodeid)};
+        return count;
+    }
+    size_t Count(NodeId nodeid) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        LOCK(m_mutex);
+        auto count{orphan_request_tracker.Count(nodeid)};
+        return count;
+    }
+
+    std::vector<GenTxid> GetOrphanRequests(NodeId nodeid, std::chrono::microseconds current_time)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        LOCK(m_mutex);
+        std::vector<std::pair<NodeId, GenTxid>> expired;
+        auto tracker_requestable = orphan_request_tracker.GetRequestable(nodeid, current_time, &expired);
+        for (const auto& entry : expired) {
+            LogPrint(BCLog::TXPACKAGES, "\nTimeout of inflight %s %s from peer=%d\n", entry.second.IsWtxid() ? "ancpkginfo" : "orphan parent",
+                entry.second.GetHash().ToString(), entry.first);
+        }
+        std::vector<GenTxid> results;
+        for (const auto& gtxid : tracker_requestable) {
+            LogPrint(BCLog::TXPACKAGES, "\nResolving orphan %s, requesting by txids of parents from peer=%d\n", gtxid.GetHash().ToString(), nodeid);
+            const auto ptx = m_orphanage.GetTx(gtxid.GetHash());
+            if (!ptx) {
+                // We can't request ancpkginfo and we have no way of knowing what the missing
+                // parents are (it could also be that the orphan has already been resolved).
+                // Give up.
+                orphan_request_tracker.ForgetTxHash(gtxid.GetHash());
+                LogPrint(BCLog::TXPACKAGES, "\nForgetting orphan %s from peer=%d\n", gtxid.GetHash().ToString(), nodeid);
+                continue;
+            }
+            // Add the orphan's parents. Net processing will filter out what we already have.
+            // Deduplicate parent txids, so that we don't have to loop over
+            // the same parent txid more than once down below.
+            std::vector<uint256> unique_parents;
+            unique_parents.reserve(ptx->vin.size());
+            for (const auto& txin : ptx->vin) {
+                // We start with all parents, and then remove duplicates below.
+                unique_parents.push_back(txin.prevout.hash);
+            }
+            std::sort(unique_parents.begin(), unique_parents.end());
+            unique_parents.erase(std::unique(unique_parents.begin(), unique_parents.end()), unique_parents.end());
+            for (const auto& txid : unique_parents) {
+                results.emplace_back(GenTxid::Txid(txid));
+            }
+            // Mark the orphan as requested
+            orphan_request_tracker.RequestedTx(nodeid, gtxid.GetHash(), current_time + ORPHAN_ANCESTOR_GETDATA_INTERVAL);
+        }
+        if (!results.empty()) LogPrint(BCLog::TXPACKAGES, "\nRequesting %u items from peer=%d\n", results.size(), nodeid);
+        return results;
+    }
+    void FinalizeTransactions(const std::set<uint256>& valid, const std::set<uint256>& invalid) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        LOCK(m_mutex);
+        for (const auto& wtxid : valid) {
+            orphan_request_tracker.ForgetTxHash(wtxid);
+        }
+        for (const auto& wtxid : invalid) {
+            orphan_request_tracker.ForgetTxHash(wtxid);
+        }
+    }
 };
 
 TxPackageTracker::TxPackageTracker() : m_impl{std::make_unique<TxPackageTracker::Impl>()} {}
@@ -41,4 +170,17 @@ void TxPackageTracker::LimitOrphans(unsigned int max_orphans) { m_impl->LimitOrp
 void TxPackageTracker::AddChildrenToWorkSet(const CTransaction& tx) { m_impl->AddChildrenToWorkSet(tx); }
 bool TxPackageTracker::HaveTxToReconsider(NodeId peer) { return m_impl->HaveTxToReconsider(peer); }
 size_t TxPackageTracker::OrphanageSize() { return m_impl->OrphanageSize(); }
+void TxPackageTracker::AddOrphanTx(NodeId nodeid, const uint256& wtxid, const CTransactionRef& tx, bool is_preferred, std::chrono::microseconds reqtime)
+{
+    m_impl->AddOrphanTx(nodeid, wtxid, tx, is_preferred, reqtime);
+}
+size_t TxPackageTracker::CountInFlight(NodeId nodeid) const { return m_impl->CountInFlight(nodeid); }
+size_t TxPackageTracker::Count(NodeId nodeid) const { return m_impl->Count(nodeid); }
+std::vector<GenTxid> TxPackageTracker::GetOrphanRequests(NodeId nodeid, std::chrono::microseconds current_time) {
+    return m_impl->GetOrphanRequests(nodeid, current_time);
+}
+void TxPackageTracker::FinalizeTransactions(const std::set<uint256>& valid, const std::set<uint256>& invalid)
+{
+    m_impl->FinalizeTransactions(valid, invalid);
+}
 } // namespace node

--- a/src/node/txpackagetracker.cpp
+++ b/src/node/txpackagetracker.cpp
@@ -1,0 +1,14 @@
+// Copyright (c) 2022
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/txpackagetracker.h>
+
+namespace node {
+class TxPackageTracker::Impl {
+};
+
+TxPackageTracker::TxPackageTracker() : m_impl{std::make_unique<TxPackageTracker::Impl>()} {}
+TxPackageTracker::~TxPackageTracker() = default;
+
+} // namespace node

--- a/src/node/txpackagetracker.cpp
+++ b/src/node/txpackagetracker.cpp
@@ -39,6 +39,10 @@ class TxPackageTracker::Impl {
             return m_txrelay && m_wtxid_relay && m_sendpackages_received;
         }
     };
+    using PackageInfoRequestId = uint256;
+    PackageInfoRequestId GetPackageInfoRequestId(NodeId nodeid, const uint256& wtxid, uint32_t version) {
+        return (CHashWriter(SER_GETHASH, 0) << nodeid << wtxid << version).GetHash();
+    }
 
     struct PeerInfo {
         // What package versions we agreed to relay.
@@ -54,12 +58,14 @@ class TxPackageTracker::Impl {
      * whether or not we relay packages with a peer. */
     std::map<NodeId, PeerInfo> info_per_peer GUARDED_BY(m_mutex);
 
-
     /** Tracks orphans for which we need to request ancestor information. All hashes stored are
      * wtxids, i.e., the wtxid of the orphan. However, the is_wtxid field is used to indicate
      * whether we would request the ancestor information by wtxid (via package relay) or by txid
      * (via prevouts of the missing inputs). */
     TxRequestTracker orphan_request_tracker GUARDED_BY(m_mutex);
+
+    /** Cache of package info requests sent. Used to identify unsolicited package info messages. */
+    CRollingBloomFilter packageinfo_requested GUARDED_BY(m_mutex){50000, 0.000001};
 
 public:
     Impl() = default;
@@ -147,17 +153,27 @@ public:
         // Skip if we weren't provided the tx and can't find the wtxid in the orphanage.
         if (tx == nullptr && !m_orphanage.HaveTx(GenTxid::Wtxid(wtxid))) return;
 
+        // Skip if already requested in the (recent-ish) past.
+        if (packageinfo_requested.contains(GetPackageInfoRequestId(nodeid, wtxid, RECEIVER_INIT_ANCESTOR_PACKAGES))) return;
+
         // Add delay to the reqtime if this peer is already using a lot of orphanage space.
         if (m_orphanage.IsOverloaded(nodeid)) reqtime += ORPHANAGE_OVERLOAD_DELAY;
 
-        // Even though this stores the orphan wtxid, is_wtxid=false because we will be requesting the parents via txid.
-        orphan_request_tracker.ReceivedInv(nodeid, GenTxid::Txid(wtxid), is_preferred, reqtime);
+        auto it_peer_info = info_per_peer.find(nodeid);
+        if (it_peer_info != info_per_peer.end() && it_peer_info->second.SupportsVersion(RECEIVER_INIT_ANCESTOR_PACKAGES)) {
+            // Package relay peer: is_wtxid=true because we will be requesting via ancpkginfo.
+            orphan_request_tracker.ReceivedInv(nodeid, GenTxid::Wtxid(wtxid), is_preferred, reqtime);
+        } else {
+            // Even though this stores the orphan wtxid, is_wtxid=false because we will be requesting the parents via txid.
+            orphan_request_tracker.ReceivedInv(nodeid, GenTxid::Txid(wtxid), is_preferred, reqtime);
+        }
 
         if (tx != nullptr) {
             m_orphanage.AddTx(tx, nodeid);
         } else {
             m_orphanage.AddTx(m_orphanage.GetTx(wtxid), nodeid);
         }
+
     }
     size_t CountInFlight(NodeId nodeid) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
     {
@@ -187,32 +203,41 @@ public:
         }
         std::vector<GenTxid> results;
         for (const auto& gtxid : tracker_requestable) {
-            LogPrint(BCLog::TXPACKAGES, "\nResolving orphan %s, requesting by txids of parents from peer=%d\n", gtxid.GetHash().ToString(), nodeid);
-            const auto ptx = m_orphanage.GetTx(gtxid.GetHash());
-            if (!ptx) {
-                // We can't request ancpkginfo and we have no way of knowing what the missing
-                // parents are (it could also be that the orphan has already been resolved).
-                // Give up.
-                orphan_request_tracker.ForgetTxHash(gtxid.GetHash());
-                LogPrint(BCLog::TXPACKAGES, "\nForgetting orphan %s from peer=%d\n", gtxid.GetHash().ToString(), nodeid);
-                continue;
+            if (gtxid.IsWtxid()) {
+                Assume(info_per_peer.find(nodeid) != info_per_peer.end());
+                // Add the orphan's wtxid as-is.
+                LogPrint(BCLog::TXPACKAGES, "\nResolving orphan %s, requesting by ancpkginfo from peer=%d\n", gtxid.GetHash().ToString(), nodeid);
+                results.emplace_back(gtxid);
+                packageinfo_requested.insert(GetPackageInfoRequestId(nodeid, gtxid.GetHash(), RECEIVER_INIT_ANCESTOR_PACKAGES));
+                orphan_request_tracker.RequestedTx(nodeid, gtxid.GetHash(), current_time + ORPHAN_ANCESTOR_GETDATA_INTERVAL);
+            } else {
+                LogPrint(BCLog::TXPACKAGES, "\nResolving orphan %s, requesting by txids of parents from peer=%d\n", gtxid.GetHash().ToString(), nodeid);
+                const auto ptx = m_orphanage.GetTx(gtxid.GetHash());
+                if (!ptx) {
+                    // We can't request ancpkginfo and we have no way of knowing what the missing
+                    // parents are (it could also be that the orphan has already been resolved).
+                    // Give up.
+                    orphan_request_tracker.ForgetTxHash(gtxid.GetHash());
+                    LogPrint(BCLog::TXPACKAGES, "\nForgetting orphan %s from peer=%d\n", gtxid.GetHash().ToString(), nodeid);
+                    continue;
+                }
+                // Add the orphan's parents. Net processing will filter out what we already have.
+                // Deduplicate parent txids, so that we don't have to loop over
+                // the same parent txid more than once down below.
+                std::vector<uint256> unique_parents;
+                unique_parents.reserve(ptx->vin.size());
+                for (const auto& txin : ptx->vin) {
+                    // We start with all parents, and then remove duplicates below.
+                    unique_parents.push_back(txin.prevout.hash);
+                }
+                std::sort(unique_parents.begin(), unique_parents.end());
+                unique_parents.erase(std::unique(unique_parents.begin(), unique_parents.end()), unique_parents.end());
+                for (const auto& txid : unique_parents) {
+                    results.emplace_back(GenTxid::Txid(txid));
+                }
+                // Mark the orphan as requested
+                orphan_request_tracker.RequestedTx(nodeid, gtxid.GetHash(), current_time + ORPHAN_ANCESTOR_GETDATA_INTERVAL);
             }
-            // Add the orphan's parents. Net processing will filter out what we already have.
-            // Deduplicate parent txids, so that we don't have to loop over
-            // the same parent txid more than once down below.
-            std::vector<uint256> unique_parents;
-            unique_parents.reserve(ptx->vin.size());
-            for (const auto& txin : ptx->vin) {
-                // We start with all parents, and then remove duplicates below.
-                unique_parents.push_back(txin.prevout.hash);
-            }
-            std::sort(unique_parents.begin(), unique_parents.end());
-            unique_parents.erase(std::unique(unique_parents.begin(), unique_parents.end()), unique_parents.end());
-            for (const auto& txid : unique_parents) {
-                results.emplace_back(GenTxid::Txid(txid));
-            }
-            // Mark the orphan as requested
-            orphan_request_tracker.RequestedTx(nodeid, gtxid.GetHash(), current_time + ORPHAN_ANCESTOR_GETDATA_INTERVAL);
         }
         if (!results.empty()) LogPrint(BCLog::TXPACKAGES, "\nRequesting %u items from peer=%d\n", results.size(), nodeid);
         return results;
@@ -228,6 +253,28 @@ public:
             orphan_request_tracker.ForgetTxHash(wtxid);
         }
     }
+    bool PkgInfoAllowed(NodeId nodeid, const uint256& wtxid, uint32_t version) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        LOCK(m_mutex);
+        if (info_per_peer.find(nodeid) == info_per_peer.end()) {
+            return false;
+        }
+        if (!packageinfo_requested.contains(GetPackageInfoRequestId(nodeid, wtxid, RECEIVER_INIT_ANCESTOR_PACKAGES))) {
+            return false;
+        }
+        orphan_request_tracker.ReceivedResponse(nodeid, wtxid);
+        return true;
+    }
+    void ForgetPkgInfo(NodeId nodeid, const uint256& rep_wtxid, uint32_t pkginfo_version) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        LOCK(m_mutex);
+        if (pkginfo_version == RECEIVER_INIT_ANCESTOR_PACKAGES) {
+            orphan_request_tracker.ReceivedResponse(nodeid, rep_wtxid);
+        }
+    }
+
 };
 
 TxPackageTracker::TxPackageTracker() : m_impl{std::make_unique<TxPackageTracker::Impl>()} {}
@@ -259,5 +306,13 @@ std::vector<GenTxid> TxPackageTracker::GetOrphanRequests(NodeId nodeid, std::chr
 void TxPackageTracker::FinalizeTransactions(const std::set<uint256>& valid, const std::set<uint256>& invalid)
 {
     m_impl->FinalizeTransactions(valid, invalid);
+}
+bool TxPackageTracker::PkgInfoAllowed(NodeId nodeid, const uint256& wtxid, uint32_t version)
+{
+    return m_impl->PkgInfoAllowed(nodeid, wtxid, version);
+}
+void TxPackageTracker::ForgetPkgInfo(NodeId nodeid, const uint256& rep_wtxid, uint32_t pkginfo_version)
+{
+    m_impl->ForgetPkgInfo(nodeid, rep_wtxid, pkginfo_version);
 }
 } // namespace node

--- a/src/node/txpackagetracker.cpp
+++ b/src/node/txpackagetracker.cpp
@@ -85,6 +85,13 @@ class TxPackageTracker::Impl {
         }
         /** Returns wtxid of representative transaction (i.e. the orphan in an ancestor package). */
         const uint256 RepresentativeWtxid() const { return m_rep_wtxid; }
+        /** Combined hash of all wtxids in package. */
+        const uint256 GetPackageHash() const {
+            std::vector<uint256> all_wtxids;
+            std::transform(m_txdata_status.cbegin(), m_txdata_status.cend(), std::back_inserter(all_wtxids),
+                [](const auto& mappair) { return mappair.first; });
+            return GetCombinedHash(all_wtxids);
+        }
     };
 
     using PackageInfoRequestId = uint256;
@@ -97,6 +104,9 @@ class TxPackageTracker::Impl {
     }
     PackageTxnsRequestId GetPackageTxnsRequestId(NodeId nodeid, const std::vector<CTransactionRef>& pkgtxns) {
         return (CHashWriter(SER_GETHASH, 0) << nodeid << GetPackageHash(pkgtxns)).GetHash();
+    }
+    PackageTxnsRequestId GetPackageTxnsRequestId(NodeId nodeid, const uint256& combinedhash) {
+        return (CHashWriter(SER_GETHASH, 0) << nodeid << combinedhash).GetHash();
     }
     /** List of all ancestor package info we're currently requesting txdata for, indexed by the
      * nodeid and getpkgtxns request we would have sent them. */
@@ -296,14 +306,15 @@ public:
     {
         AssertLockNotHeld(m_mutex);
         LOCK(m_mutex);
-        std::vector<std::pair<NodeId, GenTxid>> expired;
         // Expire packages we were trying to download tx data for
         ExpirePackageToDownload(nodeid, current_time);
+        std::vector<std::pair<NodeId, GenTxid>> expired;
         auto tracker_requestable = orphan_request_tracker.GetRequestable(nodeid, current_time, &expired);
         for (const auto& entry : expired) {
             LogPrint(BCLog::TXPACKAGES, "\nTimeout of inflight %s %s from peer=%d\n", entry.second.IsWtxid() ? "ancpkginfo" : "orphan parent",
                 entry.second.GetHash().ToString(), entry.first);
         }
+        // Get getdata requests we should send
         std::vector<GenTxid> results;
         for (const auto& gtxid : tracker_requestable) {
             if (gtxid.IsWtxid()) {
@@ -438,6 +449,51 @@ public:
         peer_info_it->second.m_package_info_provided.emplace(it);
         return false;
     }
+    void ReceivedNotFound(NodeId nodeid, const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        LOCK(m_mutex);
+        auto peer_info_it = info_per_peer.find(nodeid);
+        if (peer_info_it == info_per_peer.end()) return;
+        const auto pending_iter{pending_package_info.find(GetPackageTxnsRequestId(nodeid, hash))};
+        if (pending_iter != pending_package_info.end()) {
+            auto& pendingpackage{pending_iter->second};
+            LogPrint(BCLog::TXPACKAGES, "\nReceived notfound for package (tx %s) from peer=%d\n", pendingpackage.RepresentativeWtxid().ToString(), nodeid);
+        }
+    }
+    std::optional<PackageToValidate> ReceivedPkgTxns(NodeId nodeid, const std::vector<CTransactionRef>& package_txns)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        LOCK(m_mutex);
+        auto peer_info_it = info_per_peer.find(nodeid);
+        if (peer_info_it == info_per_peer.end()) return std::nullopt;
+        const auto pending_iter{pending_package_info.find(GetPackageTxnsRequestId(nodeid, package_txns))};
+        if (pending_iter == pending_package_info.end()) {
+            // For whatever reason, we've been sent a pkgtxns that doesn't correspond to a pending
+            // package. It's possible we already admitted all the transactions, or this response
+            // arrived past the request expiry. Drop it on the ground.
+            return std::nullopt;
+        }
+        std::vector<CTransactionRef> unvalidated_txdata(package_txns.cbegin(), package_txns.cend());
+        auto& pendingpackage{pending_iter->second};
+        LogPrint(BCLog::TXPACKAGES, "\nReceived tx data for package (tx %s) from peer=%d\n", pendingpackage.RepresentativeWtxid().ToString(), nodeid);
+        // Add the other orphanage transactions before updating pending packages map.
+        for (const auto& [wtxid, _] : pendingpackage.m_txdata_status) {
+            if (m_orphanage.HaveTx(GenTxid::Wtxid(wtxid))) {
+                unvalidated_txdata.push_back(m_orphanage.GetTx(wtxid));
+            }
+        }
+        // Only update this node's package info. We would have made a separate txdata request if for
+        // other package that also requires this transaction.
+        // update status and check if too many protected orphans
+        for (const auto& tx : package_txns) {
+            pendingpackage.UpdateStatusAndCheckSize(tx);
+        }
+        Assume(!pendingpackage.MissingTxData()); // FIXME: is this possible when honest?
+        return PackageToValidate{pendingpackage.m_pkginfo_provider, pendingpackage.RepresentativeWtxid(),
+                                 pendingpackage.GetPackageHash(), unvalidated_txdata};
+    }
 };
 
 TxPackageTracker::TxPackageTracker() : m_impl{std::make_unique<TxPackageTracker::Impl>()} {}
@@ -482,5 +538,11 @@ bool TxPackageTracker::ReceivedAncPkgInfo(NodeId nodeid, const uint256& rep_wtxi
                                           const std::vector<uint256>& missing_wtxids, std::chrono::microseconds expiry)
 {
     return m_impl->ReceivedAncPkgInfo(nodeid, rep_wtxid, txdata_status, missing_wtxids, expiry);
+}
+void TxPackageTracker::ReceivedNotFound(NodeId nodeid, const uint256& hash) { m_impl->ReceivedNotFound(nodeid, hash); }
+std::optional<TxPackageTracker::PackageToValidate> TxPackageTracker::ReceivedPkgTxns(NodeId nodeid,
+    const std::vector<CTransactionRef>& package_txns)
+{
+    return m_impl->ReceivedPkgTxns(nodeid, package_txns);
 }
 } // namespace node

--- a/src/node/txpackagetracker.cpp
+++ b/src/node/txpackagetracker.cpp
@@ -24,6 +24,36 @@ class TxPackageTracker::Impl {
     TxOrphanage m_orphanage;
 
     mutable Mutex m_mutex;
+    struct RegistrationState {
+        // All of the following bools will need to be true
+        /** Whether this peer allows transaction relay from us. */
+        bool m_txrelay{true};
+        // Whether this peer sent a BIP339 wtxidrelay message.
+        bool m_wtxid_relay{false};
+        /** Whether this peer says they can do package relay. */
+        bool m_sendpackages_received{false};
+        /** Versions of package relay supported by this node.
+         * This is a subset of PACKAGE_RELAY_SUPPORTED_VERSIONS. */
+        std::set<uint32_t> m_versions_in_common;
+        bool CanRelayPackages() {
+            return m_txrelay && m_wtxid_relay && m_sendpackages_received;
+        }
+    };
+
+    struct PeerInfo {
+        // What package versions we agreed to relay.
+        std::set<uint32_t> m_versions_supported;
+        bool SupportsVersion(uint32_t version) { return m_versions_supported.count(version) > 0; }
+    };
+
+    /** Stores relevant information about the peer prior to verack. Upon completion of version
+     * handshake, we use this information to decide whether we relay packages with this peer. */
+    std::map<NodeId, RegistrationState> registration_states GUARDED_BY(m_mutex);
+
+    /** Information for each peer we relay packages with. Membership in this map is equivalent to
+     * whether or not we relay packages with a peer. */
+    std::map<NodeId, PeerInfo> info_per_peer GUARDED_BY(m_mutex);
+
 
     /** Tracks orphans for which we need to request ancestor information. All hashes stored are
      * wtxids, i.e., the wtxid of the orphan. However, the is_wtxid field is used to indicate
@@ -42,6 +72,12 @@ public:
     {
         AssertLockNotHeld(m_mutex);
         LOCK(m_mutex);
+        if (auto it{registration_states.find(nodeid)}; it != registration_states.end()) {
+            registration_states.erase(it);
+        }
+        if (auto it{info_per_peer.find(nodeid)}; it != info_per_peer.end()) {
+            info_per_peer.erase(it);
+        }
         orphan_request_tracker.DisconnectedPeer(nodeid);
         m_orphanage.EraseForPeer(nodeid);
     }
@@ -65,6 +101,44 @@ public:
     void AddChildrenToWorkSet(const CTransaction& tx) { m_orphanage.AddChildrenToWorkSet(tx); }
     bool HaveTxToReconsider(NodeId peer) { return m_orphanage.HaveTxToReconsider(peer); }
     size_t OrphanageSize() { return m_orphanage.Size(); }
+
+    void ReceivedVersion(NodeId nodeid) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        LOCK(m_mutex);
+        if (registration_states.find(nodeid) != registration_states.end()) return;
+        registration_states.insert(std::make_pair(nodeid, RegistrationState{}));
+    }
+    void ReceivedSendpackages(NodeId nodeid, uint32_t version) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        LOCK(m_mutex);
+        const auto it = registration_states.find(nodeid);
+        if (it == registration_states.end()) return;
+        it->second.m_sendpackages_received = true;
+        // Ignore versions we don't understand.
+        if (std::count(PACKAGE_RELAY_SUPPORTED_VERSIONS.cbegin(), PACKAGE_RELAY_SUPPORTED_VERSIONS.cend(), version)) {
+            it->second.m_versions_in_common.insert(version);
+        }
+    }
+
+    bool ReceivedVerack(NodeId nodeid, bool txrelay, bool wtxidrelay) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        LOCK(m_mutex);
+        const auto& it = registration_states.find(nodeid);
+        if (it == registration_states.end()) return false;
+        it->second.m_txrelay = txrelay;
+        it->second.m_wtxid_relay = wtxidrelay;
+        const bool final_state = it->second.CanRelayPackages();
+        if (final_state) {
+            auto [peerinfo_it, success] = info_per_peer.insert(std::make_pair(nodeid, PeerInfo{}));
+            peerinfo_it->second.m_versions_supported = it->second.m_versions_in_common;
+        }
+        registration_states.erase(it);
+        return final_state;
+    }
+
     void AddOrphanTx(NodeId nodeid, const uint256& wtxid, const CTransactionRef& tx, bool is_preferred, std::chrono::microseconds reqtime)
         EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
     {
@@ -168,6 +242,11 @@ void TxPackageTracker::LimitOrphans(unsigned int max_orphans) { m_impl->LimitOrp
 void TxPackageTracker::AddChildrenToWorkSet(const CTransaction& tx) { m_impl->AddChildrenToWorkSet(tx); }
 bool TxPackageTracker::HaveTxToReconsider(NodeId peer) { return m_impl->HaveTxToReconsider(peer); }
 size_t TxPackageTracker::OrphanageSize() { return m_impl->OrphanageSize(); }
+void TxPackageTracker::ReceivedVersion(NodeId nodeid) { m_impl->ReceivedVersion(nodeid); }
+void TxPackageTracker::ReceivedSendpackages(NodeId nodeid, uint32_t version) { m_impl->ReceivedSendpackages(nodeid, version); }
+bool TxPackageTracker::ReceivedVerack(NodeId nodeid, bool txrelay, bool wtxidrelay) {
+    return m_impl->ReceivedVerack(nodeid, txrelay, wtxidrelay);
+}
 void TxPackageTracker::AddOrphanTx(NodeId nodeid, const uint256& wtxid, const CTransactionRef& tx, bool is_preferred, std::chrono::microseconds reqtime)
 {
     m_impl->AddOrphanTx(nodeid, wtxid, tx, is_preferred, reqtime);

--- a/src/node/txpackagetracker.cpp
+++ b/src/node/txpackagetracker.cpp
@@ -4,11 +4,41 @@
 
 #include <node/txpackagetracker.h>
 
+#include <txorphanage.h>
+
 namespace node {
 class TxPackageTracker::Impl {
+    /** Manages unvalidated tx data (orphan transactions for which we are downloading ancestors). */
+    TxOrphanage m_orphanage;
+public:
+    Impl() = default;
+
+    // Orphanage Wrapper Functions
+    bool OrphanageAddTx(const CTransactionRef& tx, NodeId peer) { return m_orphanage.AddTx(tx, peer); }
+    bool OrphanageHaveTx(const GenTxid& gtxid) { return m_orphanage.HaveTx(gtxid); }
+    CTransactionRef GetTxToReconsider(NodeId peer) { return m_orphanage.GetTxToReconsider(peer); }
+    int EraseOrphanTx(const uint256& txid) { return m_orphanage.EraseTx(txid); }
+    void DisconnectedPeer(NodeId peer) {
+        m_orphanage.EraseForPeer(peer);
+    }
+    void BlockConnected(const CBlock& block) { m_orphanage.EraseForBlock(block); }
+    void LimitOrphans(unsigned int max_orphans) { m_orphanage.LimitOrphans(max_orphans); }
+    void AddChildrenToWorkSet(const CTransaction& tx) { m_orphanage.AddChildrenToWorkSet(tx); }
+    bool HaveTxToReconsider(NodeId peer) { return m_orphanage.HaveTxToReconsider(peer); }
+    size_t OrphanageSize() { return m_orphanage.Size(); }
 };
 
 TxPackageTracker::TxPackageTracker() : m_impl{std::make_unique<TxPackageTracker::Impl>()} {}
 TxPackageTracker::~TxPackageTracker() = default;
 
+bool TxPackageTracker::OrphanageAddTx(const CTransactionRef& tx, NodeId peer) { return m_impl->OrphanageAddTx(tx, peer); }
+bool TxPackageTracker::OrphanageHaveTx(const GenTxid& gtxid) { return m_impl->OrphanageHaveTx(gtxid); }
+CTransactionRef TxPackageTracker::GetTxToReconsider(NodeId peer) { return m_impl->GetTxToReconsider(peer); }
+int TxPackageTracker::EraseOrphanTx(const uint256& txid) { return m_impl->EraseOrphanTx(txid); }
+void TxPackageTracker::DisconnectedPeer(NodeId peer) { m_impl->DisconnectedPeer(peer); }
+void TxPackageTracker::BlockConnected(const CBlock& block) { m_impl->BlockConnected(block); }
+void TxPackageTracker::LimitOrphans(unsigned int max_orphans) { m_impl->LimitOrphans(max_orphans); }
+void TxPackageTracker::AddChildrenToWorkSet(const CTransaction& tx) { m_impl->AddChildrenToWorkSet(tx); }
+bool TxPackageTracker::HaveTxToReconsider(NodeId peer) { return m_impl->HaveTxToReconsider(peer); }
+size_t TxPackageTracker::OrphanageSize() { return m_impl->OrphanageSize(); }
 } // namespace node

--- a/src/node/txpackagetracker.cpp
+++ b/src/node/txpackagetracker.cpp
@@ -35,7 +35,6 @@ public:
     Impl() = default;
 
     // Orphanage Wrapper Functions
-    bool OrphanageAddTx(const CTransactionRef& tx, NodeId peer) { return m_orphanage.AddTx(tx, peer); }
     bool OrphanageHaveTx(const GenTxid& gtxid) { return m_orphanage.HaveTx(gtxid); }
     CTransactionRef GetTxToReconsider(NodeId peer) { return m_orphanage.GetTxToReconsider(peer); }
     int EraseOrphanTx(const uint256& txid) { return m_orphanage.EraseTx(txid); }
@@ -160,7 +159,6 @@ public:
 TxPackageTracker::TxPackageTracker() : m_impl{std::make_unique<TxPackageTracker::Impl>()} {}
 TxPackageTracker::~TxPackageTracker() = default;
 
-bool TxPackageTracker::OrphanageAddTx(const CTransactionRef& tx, NodeId peer) { return m_impl->OrphanageAddTx(tx, peer); }
 bool TxPackageTracker::OrphanageHaveTx(const GenTxid& gtxid) { return m_impl->OrphanageHaveTx(gtxid); }
 CTransactionRef TxPackageTracker::GetTxToReconsider(NodeId peer) { return m_impl->GetTxToReconsider(peer); }
 int TxPackageTracker::EraseOrphanTx(const uint256& txid) { return m_impl->EraseOrphanTx(txid); }

--- a/src/node/txpackagetracker.cpp
+++ b/src/node/txpackagetracker.cpp
@@ -6,6 +6,7 @@
 
 #include <common/bloom.h>
 #include <logging.h>
+#include <policy/policy.h>
 #include <txorphanage.h>
 #include <txrequest.h>
 #include <util/hasher.h>
@@ -39,15 +40,80 @@ class TxPackageTracker::Impl {
             return m_txrelay && m_wtxid_relay && m_sendpackages_received;
         }
     };
+    /** Represents AncPkgInfo for which we are missing transaction data. */
+    struct PackageToDownload {
+        /** Who provided the ancpkginfo - this is the peer whose work queue to add this package when
+         * all tx data is received. We expect to receive tx data from this peer. */
+        const NodeId m_pkginfo_provider;
+
+        /** When to stop trying to download this package if we haven't received tx data yet. */
+        std::chrono::microseconds m_expiry;
+
+        /** Representative wtxid, i.e. the orphan in an ancestor package. */
+        const uint256 m_rep_wtxid;
+
+        /** Map from wtxid to status (true indicates it is missing). This can be expanded to further
+         * states such as "already in mempool/confirmed" in the future. */
+        std::map<uint256, bool> m_txdata_status;
+
+        // Package info without wtxids doesn't make sense.
+        PackageToDownload() = delete;
+        // Constructor if you already know size.
+        PackageToDownload(NodeId nodeid,
+                          std::chrono::microseconds expiry,
+                          const uint256& rep_wtxid,
+                          const std::map<uint256, bool>& txdata_status) :
+            m_pkginfo_provider{nodeid},
+            m_expiry{expiry},
+            m_rep_wtxid{rep_wtxid},
+            m_txdata_status{txdata_status}
+        {}
+        // Returns true if any tx data is still needed.
+        bool MissingTxData() {
+            return std::any_of(m_txdata_status.cbegin(), m_txdata_status.cend(),
+                               [](const auto pair){return pair.second;});
+        }
+        void UpdateStatusAndCheckSize(const CTransactionRef& tx) {
+            auto map_iter = m_txdata_status.find(tx->GetWitnessHash());
+            if (map_iter != m_txdata_status.end()) map_iter->second = false;
+        }
+        bool HasTransactionIn(const std::set<uint256>& wtxidset) const {
+            for (const auto& keyval : m_txdata_status) {
+                if (wtxidset.count(keyval.first) > 0) return true;
+            }
+            return false;
+        }
+        /** Returns wtxid of representative transaction (i.e. the orphan in an ancestor package). */
+        const uint256 RepresentativeWtxid() const { return m_rep_wtxid; }
+    };
+
     using PackageInfoRequestId = uint256;
     PackageInfoRequestId GetPackageInfoRequestId(NodeId nodeid, const uint256& wtxid, uint32_t version) {
         return (CHashWriter(SER_GETHASH, 0) << nodeid << wtxid << version).GetHash();
     }
+    using PackageTxnsRequestId = uint256;
+    PackageTxnsRequestId GetPackageTxnsRequestId(NodeId nodeid, const std::vector<uint256>& wtxids) {
+        return (CHashWriter(SER_GETHASH, 0) << nodeid << GetCombinedHash(wtxids)).GetHash();
+    }
+    PackageTxnsRequestId GetPackageTxnsRequestId(NodeId nodeid, const std::vector<CTransactionRef>& pkgtxns) {
+        return (CHashWriter(SER_GETHASH, 0) << nodeid << GetPackageHash(pkgtxns)).GetHash();
+    }
+    /** List of all ancestor package info we're currently requesting txdata for, indexed by the
+     * nodeid and getpkgtxns request we would have sent them. */
+    std::map<PackageTxnsRequestId, PackageToDownload> pending_package_info GUARDED_BY(m_mutex);
+
+    using PendingMap = decltype(pending_package_info);
+    struct IteratorComparator {
+        template<typename I>
+        bool operator()(const I& a, const I& b) const { return &(*a) < &(*b); }
+    };
 
     struct PeerInfo {
         // What package versions we agreed to relay.
         std::set<uint32_t> m_versions_supported;
         bool SupportsVersion(uint32_t version) { return m_versions_supported.count(version) > 0; }
+
+        std::set<PendingMap::iterator, IteratorComparator> m_package_info_provided;
     };
 
     /** Stores relevant information about the peer prior to verack. Upon completion of version
@@ -82,6 +148,10 @@ public:
             registration_states.erase(it);
         }
         if (auto it{info_per_peer.find(nodeid)}; it != info_per_peer.end()) {
+            for (const auto& pkginfo_iter : it->second.m_package_info_provided) {
+                it->second.m_package_info_provided.erase(pkginfo_iter);
+                pending_package_info.erase(pkginfo_iter);
+            }
             info_per_peer.erase(it);
         }
         orphan_request_tracker.DisconnectedPeer(nodeid);
@@ -180,6 +250,9 @@ public:
         AssertLockNotHeld(m_mutex);
         LOCK(m_mutex);
         auto count{orphan_request_tracker.CountInFlight(nodeid)};
+        if (auto it{info_per_peer.find(nodeid)}; it != info_per_peer.end()) {
+            count += it->second.m_package_info_provided.size();
+        }
         return count;
     }
     size_t Count(NodeId nodeid) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
@@ -187,15 +260,45 @@ public:
         AssertLockNotHeld(m_mutex);
         LOCK(m_mutex);
         auto count{orphan_request_tracker.Count(nodeid)};
+        if (auto it{info_per_peer.find(nodeid)}; it != info_per_peer.end()) {
+            count += it->second.m_package_info_provided.size();
+        }
         return count;
     }
 
+    void ExpirePackageToDownload(NodeId nodeid, std::chrono::microseconds current_time)
+        EXCLUSIVE_LOCKS_REQUIRED(m_mutex)
+    {
+        AssertLockHeld(m_mutex);
+        auto peer_info_it = info_per_peer.find(nodeid);
+        if (peer_info_it == info_per_peer.end()) return;
+        std::set<PackageTxnsRequestId> to_expire;
+        for (const auto& pkginfo_iter : peer_info_it->second.m_package_info_provided) {
+            const auto& packageinfo = pkginfo_iter->second;
+            if (packageinfo.m_expiry < current_time) {
+                LogPrint(BCLog::TXPACKAGES, "\nExpiring package info for tx %s from peer=%d\n",
+                         packageinfo.RepresentativeWtxid().ToString(), nodeid);
+                m_orphanage.EraseOrphanOfPeer(pkginfo_iter->second.m_rep_wtxid, nodeid);
+                to_expire.insert(pkginfo_iter->first);
+            }
+        }
+        for (const auto& packageid : to_expire) {
+            auto pending_iter = pending_package_info.find(packageid);
+            Assume(pending_iter != pending_package_info.end());
+            if (pending_iter != pending_package_info.end()) {
+                peer_info_it->second.m_package_info_provided.erase(pending_iter);
+                pending_package_info.erase(pending_iter);
+            }
+        }
+    }
     std::vector<GenTxid> GetOrphanRequests(NodeId nodeid, std::chrono::microseconds current_time)
         EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
     {
         AssertLockNotHeld(m_mutex);
         LOCK(m_mutex);
         std::vector<std::pair<NodeId, GenTxid>> expired;
+        // Expire packages we were trying to download tx data for
+        ExpirePackageToDownload(nodeid, current_time);
         auto tracker_requestable = orphan_request_tracker.GetRequestable(nodeid, current_time, &expired);
         for (const auto& entry : expired) {
             LogPrint(BCLog::TXPACKAGES, "\nTimeout of inflight %s %s from peer=%d\n", entry.second.IsWtxid() ? "ancpkginfo" : "orphan parent",
@@ -246,11 +349,42 @@ public:
     {
         AssertLockNotHeld(m_mutex);
         LOCK(m_mutex);
-        for (const auto& wtxid : valid) {
-            orphan_request_tracker.ForgetTxHash(wtxid);
+        // Do a linear search of all packages. This operation should not be expensive as we don't
+        // expect to be relaying more than 1 package per peer. Nonetheless, process sets together
+        // to be more efficient.
+        std::set<PackageTxnsRequestId> to_erase;
+        for (const auto& [packageid, packageinfo] : pending_package_info) {
+            const auto& rep_wtxid = packageinfo.RepresentativeWtxid();
+            if (valid.count(rep_wtxid) > 0 || invalid.count(rep_wtxid) > 0) {
+                // We have already made a final decision on the transaction of interest.
+                // There is no need to request more information from other peers.
+                to_erase.insert(packageid);
+                orphan_request_tracker.ForgetTxHash(rep_wtxid);
+            } else if (packageinfo.HasTransactionIn(invalid)) {
+                // This package info is known to contain an invalid transaction; don't continue
+                // trying to download or validate it.
+                to_erase.insert(packageid);
+                // However, as it's possible for this information to be incorrect (e.g. a peer
+                // purposefully trying to get us to reject the orphan by providing package info
+                // containing an invalid transaction), don't prevent further orphan resolution
+                // attempts with other peers.
+            } else {
+                // FIXME: Some packages may need less txdata now.
+                // It's fine not to do this *for now* since we always request all missing txdata
+                // from the same peer.
+            }
         }
-        for (const auto& wtxid : invalid) {
-            orphan_request_tracker.ForgetTxHash(wtxid);
+        for (const auto& packageid : to_erase) {
+            auto pending_iter = pending_package_info.find(packageid);
+            Assume(pending_iter != pending_package_info.end());
+            if (pending_iter != pending_package_info.end()) {
+                auto peer_info_it = info_per_peer.find(pending_iter->second.m_pkginfo_provider);
+                Assume(peer_info_it != info_per_peer.end());
+                if (peer_info_it != info_per_peer.end()) {
+                    peer_info_it->second.m_package_info_provided.erase(pending_iter);
+                }
+                pending_package_info.erase(pending_iter);
+            }
         }
     }
     bool PkgInfoAllowed(NodeId nodeid, const uint256& wtxid, uint32_t version) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
@@ -260,10 +394,15 @@ public:
         if (info_per_peer.find(nodeid) == info_per_peer.end()) {
             return false;
         }
-        if (!packageinfo_requested.contains(GetPackageInfoRequestId(nodeid, wtxid, RECEIVER_INIT_ANCESTOR_PACKAGES))) {
+        auto peer_info = info_per_peer.find(nodeid)->second;
+        const auto packageid{GetPackageInfoRequestId(nodeid, wtxid, version)};
+        if (!packageinfo_requested.contains(packageid)) {
             return false;
         }
-        orphan_request_tracker.ReceivedResponse(nodeid, wtxid);
+        // They already responded to this request.
+        for (const auto& pkginfo_iter : peer_info.m_package_info_provided) {
+            if (wtxid == pkginfo_iter->second.m_rep_wtxid) return false;
+        }
         return true;
     }
     void ForgetPkgInfo(NodeId nodeid, const uint256& rep_wtxid, uint32_t pkginfo_version) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
@@ -275,6 +414,30 @@ public:
         }
     }
 
+    bool ReceivedAncPkgInfo(NodeId nodeid, const uint256& rep_wtxid, const std::map<uint256, bool>& txdata_status,
+                            const std::vector<uint256>& missing_wtxids, std::chrono::microseconds expiry)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        AssertLockNotHeld(m_mutex);
+        LOCK(m_mutex);
+        auto peer_info_it = info_per_peer.find(nodeid);
+        if (peer_info_it == info_per_peer.end()) return true;
+        // We haven't fully resolved this orphan yet - we still need to download the txdata for each
+        // ancestor - so don't call ForgetTxHash(), as it is not guaranteed we will get all the
+        // information from this peer. Also don't call ReceivedResponse(), as doing so would trigger
+        // the orphan_request_tracker to select other candidate peers for orphan resolution. Stay
+        // in the REQUESTED, not COMPLETED, state.
+        //
+        // Instead, reset the timeout (another ORPHAN_ANCESTOR_GETDATA_INTERVAL) to give this peer
+        // more time to respond to our second round of requests. After that timeout, the
+        // orphan_request_tracker will select additional candidate peers for orphan resolution.
+        orphan_request_tracker.ResetRequestTimeout(nodeid, rep_wtxid, ORPHAN_ANCESTOR_GETDATA_INTERVAL);
+        const auto pkgtxnsid{GetPackageTxnsRequestId(nodeid, missing_wtxids)};
+        const auto [it, success] = pending_package_info.emplace(pkgtxnsid,
+            PackageToDownload{nodeid, expiry, rep_wtxid, txdata_status});
+        peer_info_it->second.m_package_info_provided.emplace(it);
+        return false;
+    }
 };
 
 TxPackageTracker::TxPackageTracker() : m_impl{std::make_unique<TxPackageTracker::Impl>()} {}
@@ -314,5 +477,10 @@ bool TxPackageTracker::PkgInfoAllowed(NodeId nodeid, const uint256& wtxid, uint3
 void TxPackageTracker::ForgetPkgInfo(NodeId nodeid, const uint256& rep_wtxid, uint32_t pkginfo_version)
 {
     m_impl->ForgetPkgInfo(nodeid, rep_wtxid, pkginfo_version);
+}
+bool TxPackageTracker::ReceivedAncPkgInfo(NodeId nodeid, const uint256& rep_wtxid, const std::map<uint256, bool>& txdata_status,
+                                          const std::vector<uint256>& missing_wtxids, std::chrono::microseconds expiry)
+{
+    return m_impl->ReceivedAncPkgInfo(nodeid, rep_wtxid, txdata_status, missing_wtxids, expiry);
 }
 } // namespace node

--- a/src/node/txpackagetracker.h
+++ b/src/node/txpackagetracker.h
@@ -98,6 +98,15 @@ public:
      * Should not be called when a tx fails validation.
      * */
     void FinalizeTransactions(const std::set<uint256>& valid, const std::set<uint256>& invalid);
+
+    /** Whether a package info message is allowed:
+     * - We agreed to relay packages of this version with this peer.
+     * - We solicited this package info.
+     * Returns false if the peer should be disconnected. */
+    bool PkgInfoAllowed(NodeId nodeid, const uint256& wtxid, uint32_t version);
+
+    /** Record receipt of a notfound message for pkginfo. */
+    void ForgetPkgInfo(NodeId nodeid, const uint256& rep_wtxid, uint32_t pkginfo_version);
 };
 } // namespace node
 #endif // BITCOIN_NODE_TXPACKAGETRACKER_H

--- a/src/node/txpackagetracker.h
+++ b/src/node/txpackagetracker.h
@@ -15,6 +15,10 @@ class CBlock;
 class TxOrphanage;
 namespace node {
 static constexpr bool DEFAULT_ENABLE_PACKAGE_RELAY{false};
+static constexpr uint32_t RECEIVER_INIT_ANCESTOR_PACKAGES{0};
+static std::vector<uint32_t> PACKAGE_RELAY_SUPPORTED_VERSIONS = {
+    RECEIVER_INIT_ANCESTOR_PACKAGES,
+};
 
 class TxPackageTracker {
     class Impl;
@@ -55,6 +59,14 @@ public:
 
     /** Return how many entries exist in the orphange */
     size_t OrphanageSize();
+
+    std::vector<uint32_t> GetVersions() { return PACKAGE_RELAY_SUPPORTED_VERSIONS; }
+
+    // We expect this to be called only once
+    void ReceivedVersion(NodeId nodeid);
+    void ReceivedSendpackages(NodeId nodeid, uint32_t version);
+    // Finalize the registration state.
+    bool ReceivedVerack(NodeId nodeid, bool txrelay, bool wtxidrelay);
 
     /** Received an announcement from this peer for a tx we already know is an orphan; should be
      * called for every peer that announces the tx, even if they are not a package relay peer.

--- a/src/node/txpackagetracker.h
+++ b/src/node/txpackagetracker.h
@@ -113,6 +113,36 @@ public:
      * and when to expire it. */
     bool ReceivedAncPkgInfo(NodeId nodeid, const uint256& rep_wtxid, const std::map<uint256, bool>& txdata_status,
                             const std::vector<uint256>& missing_wtxids, std::chrono::microseconds expiry);
+
+    /** Record receipt of notfound message for pkgtxns. */
+    void ReceivedNotFound(NodeId nodeid, const uint256& hash);
+
+    struct PackageToValidate {
+        /** Who provided the package info. */
+        const NodeId m_info_provider;
+        /** Representative transaction, i.e. orphan in an ancestor package. */
+        const uint256 m_rep_wtxid;
+        /** Combined hash of all transactions in package info. Used to cache failure. */
+        const uint256 m_pkginfo_hash;
+        /** Transactions to submit for mempool validation. */
+        const Package m_unvalidated_txns;
+
+        PackageToValidate() = delete;
+        PackageToValidate(NodeId info_provider,
+                          const uint256& rep_wtxid,
+                          const uint256& pkginfo_hash,
+                          const Package& txns) :
+            m_info_provider{info_provider},
+            m_rep_wtxid{rep_wtxid},
+            m_pkginfo_hash{pkginfo_hash},
+            m_unvalidated_txns{txns}
+        {}
+    };
+
+    /** If there is a package that is missing this tx data, updates the PendingPackage and
+     * returns a PackageToValidate including the other txdata stored in the orphanage.
+     */
+    std::optional<PackageToValidate> ReceivedPkgTxns(NodeId nodeid, const std::vector<CTransactionRef>& package_txns);
 };
 } // namespace node
 #endif // BITCOIN_NODE_TXPACKAGETRACKER_H

--- a/src/node/txpackagetracker.h
+++ b/src/node/txpackagetracker.h
@@ -25,9 +25,6 @@ public:
     ~TxPackageTracker();
 
     // Orphanage wrapper functions
-    /** Add new tx to orphanage if it isn't already there. Returns whether the tx was added. */
-    bool OrphanageAddTx(const CTransactionRef& tx, NodeId peer);
-
     /** Check if we already have an orphan transaction (by txid or wtxid) */
     bool OrphanageHaveTx(const GenTxid& gtxid);
 

--- a/src/node/txpackagetracker.h
+++ b/src/node/txpackagetracker.h
@@ -11,6 +11,7 @@
 #include <map>
 #include <vector>
 
+class TxOrphanage;
 namespace node {
 static constexpr bool DEFAULT_ENABLE_PACKAGE_RELAY{false};
 
@@ -21,6 +22,42 @@ class TxPackageTracker {
 public:
     explicit TxPackageTracker();
     ~TxPackageTracker();
+
+    // Orphanage wrapper functions
+    /** Add new tx to orphanage if it isn't already there. Returns whether the tx was added. */
+    bool OrphanageAddTx(const CTransactionRef& tx, NodeId peer);
+
+    /** Check if we already have an orphan transaction (by txid or wtxid) */
+    bool OrphanageHaveTx(const GenTxid& gtxid);
+
+    /** Extract a transaction from a peer's work set
+     *  Returns nullptr if there are no transactions to work on.
+     *  Otherwise returns the transaction reference, and removes
+     *  it from the work set.
+     */
+    CTransactionRef GetTxToReconsider(NodeId peer);
+
+    /** Erase an orphan by txid */
+    int EraseOrphanTx(const uint256& txid);
+
+    /** Erase all orphans announced by a peer (eg, after that peer disconnects) */
+    void DisconnectedPeer(NodeId peer);
+
+    /** Erase all orphans included in or invalidated by a new block */
+    void BlockConnected(const CBlock& block);
+
+    /** Limit the orphanage to the given maximum */
+    void LimitOrphans(unsigned int max_orphans);
+
+    /** Add any orphans that list a particular tx as a parent into the from peer's work set */
+    void AddChildrenToWorkSet(const CTransaction& tx);
+
+    /** Does this peer have any orphans to validate? */
+    bool HaveTxToReconsider(NodeId peer);
+
+    /** Return how many entries exist in the orphange */
+    size_t OrphanageSize();
+
 };
 } // namespace node
 #endif // BITCOIN_NODE_TXPACKAGETRACKER_H

--- a/src/node/txpackagetracker.h
+++ b/src/node/txpackagetracker.h
@@ -6,6 +6,7 @@
 #define BITCOIN_NODE_TXPACKAGETRACKER_H
 
 #include <net.h>
+#include <policy/packages.h>
 
 #include <cstdint>
 #include <map>
@@ -107,6 +108,11 @@ public:
 
     /** Record receipt of a notfound message for pkginfo. */
     void ForgetPkgInfo(NodeId nodeid, const uint256& rep_wtxid, uint32_t pkginfo_version);
+
+    /** Record receipt of an ancpkginfo, which transactions are missing (and requested),
+     * and when to expire it. */
+    bool ReceivedAncPkgInfo(NodeId nodeid, const uint256& rep_wtxid, const std::map<uint256, bool>& txdata_status,
+                            const std::vector<uint256>& missing_wtxids, std::chrono::microseconds expiry);
 };
 } // namespace node
 #endif // BITCOIN_NODE_TXPACKAGETRACKER_H

--- a/src/node/txpackagetracker.h
+++ b/src/node/txpackagetracker.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODE_TXPACKAGETRACKER_H
+#define BITCOIN_NODE_TXPACKAGETRACKER_H
+
+#include <net.h>
+
+#include <cstdint>
+#include <map>
+#include <vector>
+
+namespace node {
+static constexpr bool DEFAULT_ENABLE_PACKAGE_RELAY{false};
+
+class TxPackageTracker {
+    class Impl;
+    const std::unique_ptr<Impl> m_impl;
+
+public:
+    explicit TxPackageTracker();
+    ~TxPackageTracker();
+};
+} // namespace node
+#endif // BITCOIN_NODE_TXPACKAGETRACKER_H

--- a/src/policy/packages.cpp
+++ b/src/policy/packages.cpp
@@ -51,7 +51,7 @@ bool IsConsistent(const Package& txns)
     return true;
 }
 
-bool IsPackageWellFormed(const Package& txns, PackageValidationState& state)
+bool IsPackageWellFormed(const Package& txns, PackageValidationState& state, bool require_sorted)
 {
     const unsigned int package_count = txns.size();
 
@@ -70,7 +70,7 @@ bool IsPackageWellFormed(const Package& txns, PackageValidationState& state)
     // An unsorted package will fail anyway on missing-inputs, but it's better to quit earlier and
     // fail on something less ambiguous (missing-inputs could also be an orphan or trying to
     // spend nonexistent coins).
-    if (!IsSorted(txns)) return state.Invalid(PackageValidationResult::PCKG_POLICY, "package-not-sorted");
+    if (require_sorted && !IsSorted(txns)) return state.Invalid(PackageValidationResult::PCKG_POLICY, "package-not-sorted");
     if (!IsConsistent(txns)) return state.Invalid(PackageValidationResult::PCKG_POLICY, "conflict-in-package");
     return true;
 }

--- a/src/policy/packages.cpp
+++ b/src/policy/packages.cpp
@@ -15,6 +15,43 @@
 #include <numeric>
 #include <unordered_set>
 
+bool IsSorted(const Package& txns)
+{
+    std::unordered_set<uint256, SaltedTxidHasher> later_txids;
+    std::transform(txns.cbegin(), txns.cend(), std::inserter(later_txids, later_txids.end()),
+                   [](const auto& tx) { return tx->GetHash(); });
+    for (const auto& tx : txns) {
+        for (const auto& input : tx->vin) {
+            if (later_txids.find(input.prevout.hash) != later_txids.end()) {
+                // The parent is a subsequent transaction in the package.
+                return false;
+            }
+        }
+        later_txids.erase(tx->GetHash());
+    }
+    return true;
+}
+
+bool IsConsistent(const Package& txns)
+{
+    // Don't allow any conflicting transactions, i.e. spending the same inputs, in a package.
+    std::unordered_set<COutPoint, SaltedOutpointHasher> inputs_seen;
+    for (const auto& tx : txns) {
+        for (const auto& input : tx->vin) {
+            if (inputs_seen.find(input.prevout) != inputs_seen.end()) {
+                // This input is also present in another tx in the package.
+                return false;
+            }
+        }
+        // Batch-add all the inputs for a tx at a time. If we added them 1 at a time, we could
+        // catch duplicate inputs within a single tx.  This is a more severe, consensus error,
+        // and we want to report that from CheckTransaction instead.
+        std::transform(tx->vin.cbegin(), tx->vin.cend(), std::inserter(inputs_seen, inputs_seen.end()),
+                       [](const auto& input) { return input.prevout; });
+    }
+    return true;
+}
+
 bool CheckPackage(const Package& txns, PackageValidationState& state)
 {
     const unsigned int package_count = txns.size();
@@ -34,34 +71,8 @@ bool CheckPackage(const Package& txns, PackageValidationState& state)
     // An unsorted package will fail anyway on missing-inputs, but it's better to quit earlier and
     // fail on something less ambiguous (missing-inputs could also be an orphan or trying to
     // spend nonexistent coins).
-    std::unordered_set<uint256, SaltedTxidHasher> later_txids;
-    std::transform(txns.cbegin(), txns.cend(), std::inserter(later_txids, later_txids.end()),
-                   [](const auto& tx) { return tx->GetHash(); });
-    for (const auto& tx : txns) {
-        for (const auto& input : tx->vin) {
-            if (later_txids.find(input.prevout.hash) != later_txids.end()) {
-                // The parent is a subsequent transaction in the package.
-                return state.Invalid(PackageValidationResult::PCKG_POLICY, "package-not-sorted");
-            }
-        }
-        later_txids.erase(tx->GetHash());
-    }
-
-    // Don't allow any conflicting transactions, i.e. spending the same inputs, in a package.
-    std::unordered_set<COutPoint, SaltedOutpointHasher> inputs_seen;
-    for (const auto& tx : txns) {
-        for (const auto& input : tx->vin) {
-            if (inputs_seen.find(input.prevout) != inputs_seen.end()) {
-                // This input is also present in another tx in the package.
-                return state.Invalid(PackageValidationResult::PCKG_POLICY, "conflict-in-package");
-            }
-        }
-        // Batch-add all the inputs for a tx at a time. If we added them 1 at a time, we could
-        // catch duplicate inputs within a single tx.  This is a more severe, consensus error,
-        // and we want to report that from CheckTransaction instead.
-        std::transform(tx->vin.cbegin(), tx->vin.cend(), std::inserter(inputs_seen, inputs_seen.end()),
-                       [](const auto& input) { return input.prevout; });
-    }
+    if (!IsSorted(txns)) return state.Invalid(PackageValidationResult::PCKG_POLICY, "package-not-sorted");
+    if (!IsConsistent(txns)) return state.Invalid(PackageValidationResult::PCKG_POLICY, "conflict-in-package");
     return true;
 }
 

--- a/src/policy/packages.cpp
+++ b/src/policy/packages.cpp
@@ -52,7 +52,7 @@ bool IsConsistent(const Package& txns)
     return true;
 }
 
-bool CheckPackage(const Package& txns, PackageValidationState& state)
+bool IsPackageWellFormed(const Package& txns, PackageValidationState& state)
 {
     const unsigned int package_count = txns.size();
 

--- a/src/policy/packages.cpp
+++ b/src/policy/packages.cpp
@@ -5,7 +5,7 @@
 #include <policy/packages.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
-#include <uint256.h>
+#include <util/check.h>
 #include <util/hasher.h>
 
 #include <algorithm>
@@ -13,7 +13,6 @@
 #include <iterator>
 #include <memory>
 #include <numeric>
-#include <unordered_set>
 
 bool IsSorted(const Package& txns)
 {
@@ -91,4 +90,87 @@ bool IsChildWithParents(const Package& package)
     // Every transaction must be a parent of the last transaction in the package.
     return std::all_of(package.cbegin(), package.cend() - 1,
                        [&input_txids](const auto& ptx) { return input_txids.count(ptx->GetHash()) > 0; });
+}
+
+// Calculates curr_tx's in-package ancestor set. If the tx spends another tx in the package, calls
+// visit() for that transaction first, since any transaction's ancestor set includes its parents'
+// ancestor sets. Transaction dependency cycles are not possible without breaking sha256 and
+// duplicate transactions were checked in the Packageifier() ctor, so this won't recurse infinitely.
+// After this function returns, curr_tx is guaranteed to be in the ancestor_subsets map.
+void Packageifier::visit(const CTransactionRef& curr_tx)
+{
+    const uint256& curr_txid = curr_tx->GetHash();
+    if (ancestor_subsets.count(curr_txid) > 0) return;
+    std::set<uint256> my_ancestors;
+    my_ancestors.insert(curr_txid);
+    for (const auto& input : curr_tx->vin) {
+        auto parent_tx = txid_to_tx.find(input.prevout.hash);
+        if (parent_tx == txid_to_tx.end()) continue;
+        if (ancestor_subsets.count(parent_tx->first) == 0) {
+            visit(parent_tx->second);
+        }
+        auto parent_ancestor_set = ancestor_subsets.find(parent_tx->first);
+        my_ancestors.insert(parent_ancestor_set->second.cbegin(), parent_ancestor_set->second.cend());
+    }
+    ancestor_subsets.insert(std::make_pair(curr_txid, my_ancestors));
+}
+
+Packageifier::Packageifier(const Package& txns_in)
+{
+    // Duplicate transactions are not allowed, as they will result in infinite visit() recusion.
+    Assume(IsConsistent(txns_in));
+    // Populate txid_to_tx for quick lookup
+    std::transform(txns_in.cbegin(), txns_in.cend(), std::inserter(txid_to_tx, txid_to_tx.end()),
+            [](const auto& tx) { return std::make_pair(tx->GetHash(), tx); });
+    // DFS-based algorithm to sort transactions by ancestor count and populate ancestor_subsets cache.
+    // Best case runtime is if the package is already sorted and no recursive calls happen.
+    // Exclusion from ancestor_subsets is equivalent to not yet being fully processed.
+    size_t i{0};
+    while (ancestor_subsets.size() < txns_in.size() && i < txns_in.size()) {
+        const auto& tx = txns_in[i];
+        if (ancestor_subsets.count(tx->GetHash()) == 0) visit(tx);
+        Assume(ancestor_subsets.count(tx->GetHash()) == 1);
+        ++i;
+    }
+    txns = txns_in;
+    // Sort by the number of in-package ancestors.
+    std::sort(txns.begin(), txns.end(), [&](const CTransactionRef& a, const CTransactionRef& b) -> bool {
+        auto a_ancestors = ancestor_subsets.find(a->GetHash());
+        auto b_ancestors = ancestor_subsets.find(b->GetHash());
+        return a_ancestors->second.size() < b_ancestors->second.size();
+    });
+    Assume(IsSorted(txns));
+}
+
+std::optional<std::vector<CTransactionRef>> Packageifier::GetAncestorSet(const CTransactionRef& tx)
+{
+    auto ancestor_set = ancestor_subsets.find(tx->GetHash());
+    std::vector<CTransactionRef> result;
+    for (const auto& txid : ancestor_set->second) {
+        if (banned_txns.find(txid) != banned_txns.end()) {
+            return std::nullopt;
+        }
+    }
+    result.reserve(ancestor_set->second.size());
+    for (const auto& txid : ancestor_set->second) {
+        auto it = txid_to_tx.find(txid);
+        if (excluded_txns.find(txid) == excluded_txns.end()) {
+            result.push_back(it->second);
+        }
+    }
+    std::sort(result.begin(), result.end(), [&](const CTransactionRef& a, const CTransactionRef& b) -> bool {
+        auto a_ancestors = ancestor_subsets.find(a->GetHash());
+        auto b_ancestors = ancestor_subsets.find(b->GetHash());
+        return a_ancestors->second.size() < b_ancestors->second.size();
+    });
+    return result;
+}
+
+void Packageifier::Exclude(const CTransactionRef& transaction)
+{
+    excluded_txns.insert(transaction->GetHash());
+}
+void Packageifier::Ban(const CTransactionRef& transaction)
+{
+    banned_txns.insert(transaction->GetHash());
 }

--- a/src/policy/packages.cpp
+++ b/src/policy/packages.cpp
@@ -174,3 +174,18 @@ void Packageifier::Ban(const CTransactionRef& transaction)
 {
     banned_txns.insert(transaction->GetHash());
 }
+
+uint256 GetCombinedHash(const std::vector<uint256>& wtxids)
+{
+    std::vector<uint256> wtxids_copy(wtxids.cbegin(), wtxids.cend());
+    std::sort(wtxids_copy.begin(), wtxids_copy.end());
+    return (CHashWriter(SER_GETHASH, 0) << wtxids_copy).GetHash();
+}
+uint256 GetPackageHash(const std::vector<CTransactionRef>& transactions)
+{
+    std::vector<uint256> wtxids_copy;
+    std::transform(transactions.cbegin(), transactions.cend(), std::back_inserter(wtxids_copy),
+        [](const auto& tx){ return tx->GetWitnessHash(); });
+    std::sort(wtxids_copy.begin(), wtxids_copy.end());
+    return (CHashWriter(SER_GETHASH, 0) << wtxids_copy).GetHash();
+}

--- a/src/policy/packages.h
+++ b/src/policy/packages.h
@@ -65,7 +65,7 @@ bool IsConsistent(const Package& txns);
  * 3. If any dependencies exist between transactions, parents must appear before children.
  * 4. Transactions cannot conflict, i.e., spend the same inputs.
  */
-bool CheckPackage(const Package& txns, PackageValidationState& state);
+bool IsPackageWellFormed(const Package& txns, PackageValidationState& state);
 
 /** Context-free check that a package is exactly one child and its parents; not all parents need to
  * be present, but the package must not contain any transactions that are not the child's parents.

--- a/src/policy/packages.h
+++ b/src/policy/packages.h
@@ -68,7 +68,7 @@ bool IsConsistent(const Package& txns);
  * 3. If any dependencies exist between transactions, parents must appear before children.
  * 4. Transactions cannot conflict, i.e., spend the same inputs.
  */
-bool IsPackageWellFormed(const Package& txns, PackageValidationState& state);
+bool IsPackageWellFormed(const Package& txns, PackageValidationState& state, bool require_sorted);
 
 /** Context-free check that a package is exactly one child and its parents; not all parents need to
  * be present, but the package must not contain any transactions that are not the child's parents.

--- a/src/policy/packages.h
+++ b/src/policy/packages.h
@@ -45,6 +45,20 @@ using Package = std::vector<CTransactionRef>;
 
 class PackageValidationState : public ValidationState<PackageValidationResult> {};
 
+/** If any direct dependencies exist between transactions (i.e. a child spending the output of a
+ * parent), checks that all parents appear somewhere in the list before their respective children.
+ * This function cannot detect indirect dependencies (e.g. a transaction's grandparent if its parent
+ * is not present).
+ * @returns true if sorted. False if any tx spends the output of a tx that appears later in txns.
+ */
+bool IsSorted(const Package& txns);
+
+/** Checks that none of the transactions conflict, i.e., spend the same prevout. Consequently also
+ * checks that there are no duplicate transactions.
+ * @returns true if there are no conflicts. False if any two transactions spend the same prevout.
+ * */
+bool IsConsistent(const Package& txns);
+
 /** Context-free package policy checks:
  * 1. The number of transactions cannot exceed MAX_PACKAGE_COUNT.
  * 2. The total virtual size cannot exceed MAX_PACKAGE_SIZE.

--- a/src/policy/packages.h
+++ b/src/policy/packages.h
@@ -9,8 +9,11 @@
 #include <consensus/validation.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
+#include <uint256.h>
+#include <util/hasher.h>
 
 #include <cstdint>
+#include <unordered_set>
 #include <vector>
 
 /** Default maximum number of transactions in a package. */
@@ -73,4 +76,41 @@ bool IsPackageWellFormed(const Package& txns, PackageValidationState& state);
  */
 bool IsChildWithParents(const Package& package);
 
+class Packageifier
+{
+    /** Transactions sorted topologically (see IsSorted()). */
+    Package txns;
+    /** Map from txid to transaction for quick lookup. */
+    std::map<uint256, CTransactionRef> txid_to_tx;
+    /** Cache of the in-package ancestors for each transaction, indexed by txid. */
+    std::map<uint256, std::set<uint256>> ancestor_subsets;
+    /** Txids of transactions to exclude when returning ancestor subsets.*/
+    std::unordered_set<uint256, SaltedTxidHasher> excluded_txns;
+    /** Txids of transactions that are banned. Return nullopt from GetAncestorSet() if it contains
+     * any of these transactions.*/
+    std::unordered_set<uint256, SaltedTxidHasher> banned_txns;
+
+    /** Helper function for recursively constructing ancestor caches in ctor. */
+    void visit(const CTransactionRef&);
+public:
+    /** Constructs ancestor package, sorting the transactions topologically and constructing the
+     * txid_to_tx and ancestor_subsets maps. It is ok if the input txns is not sorted.
+     * Expects:
+     * - No duplicate transactions.
+     * - No conflicts between transactions.
+     * - txns is of reasonable size (e.g. below MAX_PACKAGE_COUNT) to limit recursion depth
+     */
+    Packageifier(const Package& txns);
+    /** Returns the transactions, in ascending order of number of in-package ancestors. */
+    Package Txns() const { return txns; }
+    /** Get the ancestor subpackage for a tx, sorted so that ancestors appear before descendants.
+     * The list includes the tx. If this transaction depends on a Banned tx, returns std::nullopt.
+     * If one or more ancestors have been Excluded, they will not appear in the result. */
+    std::optional<std::vector<CTransactionRef>> GetAncestorSet(const CTransactionRef& tx);
+    /** From now on, exclude this tx from any result in GetAncestorSet(). Does not affect Txns(). */
+    void Exclude(const CTransactionRef& transaction);
+    /** Mark a transaction as "banned." From now on, if this transaction is present in the ancestor
+     * set, GetAncestorSet() should return std::nullopt for that tx. Does not affect Txns(). */
+    void Ban(const CTransactionRef& transaction);
+};
 #endif // BITCOIN_POLICY_PACKAGES_H

--- a/src/policy/packages.h
+++ b/src/policy/packages.h
@@ -113,4 +113,11 @@ public:
      * set, GetAncestorSet() should return std::nullopt for that tx. Does not affect Txns(). */
     void Ban(const CTransactionRef& transaction);
 };
+
+
+/** Get the hash of these wtxids, concatenated in lexicographical order. */
+uint256 GetCombinedHash(const std::vector<uint256>& wtxids);
+/** Get the hash of these transactions' wtxids, concatenated in lexicographical order. */
+uint256 GetPackageHash(const std::vector<CTransactionRef>& transactions);
+
 #endif // BITCOIN_POLICY_PACKAGES_H

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -46,6 +46,7 @@ const char *CFCHECKPT="cfcheckpt";
 const char *WTXIDRELAY="wtxidrelay";
 const char *SENDTXRCNCL="sendtxrcncl";
 const char *SENDPACKAGES="sendpackages";
+const char *ANCPKGINFO="ancpkginfo";
 } // namespace NetMsgType
 
 /** All known message types. Keep this in the same order as the list of
@@ -88,6 +89,7 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::WTXIDRELAY,
     NetMsgType::SENDTXRCNCL,
     NetMsgType::SENDPACKAGES,
+    NetMsgType::ANCPKGINFO,
 };
 const static std::vector<std::string> allNetMessageTypesVec(std::begin(allNetMessageTypes), std::end(allNetMessageTypes));
 
@@ -166,6 +168,7 @@ std::string CInv::GetCommand() const
     case MSG_BLOCK:          return cmd.append(NetMsgType::BLOCK);
     case MSG_FILTERED_BLOCK: return cmd.append(NetMsgType::MERKLEBLOCK);
     case MSG_CMPCT_BLOCK:    return cmd.append(NetMsgType::CMPCTBLOCK);
+    case MSG_ANCPKGINFO:     return cmd.append(NetMsgType::ANCPKGINFO);
     default:
         throw std::out_of_range(strprintf("CInv::GetCommand(): type=%d unknown type", type));
     }
@@ -221,6 +224,6 @@ std::vector<std::string> serviceFlagsToStr(uint64_t flags)
 
 GenTxid ToGenTxid(const CInv& inv)
 {
-    assert(inv.IsGenTxMsg());
+    assert(inv.IsGenTxMsg() || inv.IsMsgAncPkgInfo());
     return inv.IsMsgWtx() ? GenTxid::Wtxid(inv.hash) : GenTxid::Txid(inv.hash);
 }

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -47,6 +47,8 @@ const char *WTXIDRELAY="wtxidrelay";
 const char *SENDTXRCNCL="sendtxrcncl";
 const char *SENDPACKAGES="sendpackages";
 const char *ANCPKGINFO="ancpkginfo";
+const char *GETPKGTXNS="getpkgtxns";
+const char *PKGTXNS="pkgtxns";
 } // namespace NetMsgType
 
 /** All known message types. Keep this in the same order as the list of
@@ -90,6 +92,8 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::SENDTXRCNCL,
     NetMsgType::SENDPACKAGES,
     NetMsgType::ANCPKGINFO,
+    NetMsgType::GETPKGTXNS,
+    NetMsgType::PKGTXNS,
 };
 const static std::vector<std::string> allNetMessageTypesVec(std::begin(allNetMessageTypes), std::end(allNetMessageTypes));
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -45,6 +45,7 @@ const char *GETCFCHECKPT="getcfcheckpt";
 const char *CFCHECKPT="cfcheckpt";
 const char *WTXIDRELAY="wtxidrelay";
 const char *SENDTXRCNCL="sendtxrcncl";
+const char *SENDPACKAGES="sendpackages";
 } // namespace NetMsgType
 
 /** All known message types. Keep this in the same order as the list of
@@ -86,6 +87,7 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::CFCHECKPT,
     NetMsgType::WTXIDRELAY,
     NetMsgType::SENDTXRCNCL,
+    NetMsgType::SENDPACKAGES,
 };
 const static std::vector<std::string> allNetMessageTypesVec(std::begin(allNetMessageTypes), std::end(allNetMessageTypes));
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -268,6 +268,8 @@ extern const char* SENDTXRCNCL;
  * Indicates that a node wants to relay packages, described in BIP 331.
  */
 extern const char* SENDPACKAGES;
+/** List of wtxids corresponding to a transaction's ancestor package. */
+extern const char* ANCPKGINFO;
 }; // namespace NetMsgType
 
 /* Get a vector of all valid message types (see above) */
@@ -475,6 +477,7 @@ enum GetDataMsg : uint32_t {
     // MSG_FILTERED_WITNESS_BLOCK is defined in BIP144 as reserved for future
     // use and remains unused.
     // MSG_FILTERED_WITNESS_BLOCK = MSG_FILTERED_BLOCK | MSG_WITNESS_FLAG,
+    MSG_ANCPKGINFO = 6,
 };
 
 /** inv message data */
@@ -498,6 +501,7 @@ public:
     bool IsMsgFilteredBlk() const { return type == MSG_FILTERED_BLOCK; }
     bool IsMsgCmpctBlk() const { return type == MSG_CMPCT_BLOCK; }
     bool IsMsgWitnessBlk() const { return type == MSG_WITNESS_BLOCK; }
+    bool IsMsgAncPkgInfo() const { return type == MSG_ANCPKGINFO; }
 
     // Combined-message helper methods
     bool IsGenTxMsg() const

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -264,6 +264,10 @@ extern const char* WTXIDRELAY;
  * txreconciliation, as described by BIP 330.
  */
 extern const char* SENDTXRCNCL;
+/**
+ * Indicates that a node wants to relay packages, described in BIP 331.
+ */
+extern const char* SENDPACKAGES;
 }; // namespace NetMsgType
 
 /* Get a vector of all valid message types (see above) */

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -270,6 +270,14 @@ extern const char* SENDTXRCNCL;
 extern const char* SENDPACKAGES;
 /** List of wtxids corresponding to a transaction's ancestor package. */
 extern const char* ANCPKGINFO;
+/**
+ * Requests all or none of a list of transactions, specified by wtxid.
+ */
+extern const char* GETPKGTXNS;
+/**
+ * List of transactions.
+ */
+extern const char* PKGTXNS;
 }; // namespace NetMsgType
 
 /* Get a vector of all valid message types (see above) */
@@ -477,7 +485,8 @@ enum GetDataMsg : uint32_t {
     // MSG_FILTERED_WITNESS_BLOCK is defined in BIP144 as reserved for future
     // use and remains unused.
     // MSG_FILTERED_WITNESS_BLOCK = MSG_FILTERED_BLOCK | MSG_WITNESS_FLAG,
-    MSG_ANCPKGINFO = 6,
+    MSG_ANCPKGINFO = 6,                              //!< Defined in BIP331
+    MSG_PKGTXNS = 7,                                 //!< Defined in BIP331
 };
 
 /** inv message data */
@@ -502,6 +511,7 @@ public:
     bool IsMsgCmpctBlk() const { return type == MSG_CMPCT_BLOCK; }
     bool IsMsgWitnessBlk() const { return type == MSG_WITNESS_BLOCK; }
     bool IsMsgAncPkgInfo() const { return type == MSG_ANCPKGINFO; }
+    bool IsMsgPkgTxns() const { return type == MSG_PKGTXNS; }
 
     // Combined-message helper methods
     bool IsGenTxMsg() const

--- a/src/rpc/mempool.cpp
+++ b/src/rpc/mempool.cpp
@@ -759,11 +759,10 @@ static RPCHelpMan savemempool()
 static RPCHelpMan submitpackage()
 {
     return RPCHelpMan{"submitpackage",
-        "Submit a package of raw transactions (serialized, hex-encoded) to local node (-regtest only).\n"
+        "Submit a package of raw transactions (serialized, hex-encoded) to local node.\n"
         "The package will be validated according to consensus and mempool policy rules. If all transactions pass, they will be accepted to mempool.\n"
         "This RPC is experimental and the interface may be unstable. Refer to doc/policy/packages.md for documentation on package policies.\n"
-        "Warning: until package relay is in use, successful submission does not mean the transaction will propagate to other nodes on the network.\n"
-        "Currently, each transaction is broadcasted individually after submission, which means they must meet other nodes' feerate requirements alone.\n"
+        "Warning: unless this node and others are using package relay (-packagerelay), successful submission does not mean the transactions will propagate throughout the network.\n"
         ,
         {
             {"package", RPCArg::Type::ARR, RPCArg::Optional::NO, "An array of raw transactions.",
@@ -802,9 +801,6 @@ static RPCHelpMan submitpackage()
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
         {
-            if (!Params().IsMockableChain()) {
-                throw std::runtime_error("submitpackage is for regression testing (-regtest mode) only");
-            }
             const UniValue raw_transactions = request.params[0].get_array();
             if (raw_transactions.size() < 1 || raw_transactions.size() > MAX_PACKAGE_COUNT) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER,
@@ -922,7 +918,7 @@ void RegisterMempoolRPCCommands(CRPCTable& t)
         {"blockchain", &getmempoolinfo},
         {"blockchain", &getrawmempool},
         {"blockchain", &savemempool},
-        {"hidden", &submitpackage},
+        {"rawtransactions", &submitpackage},
     };
     for (const auto& c : commands) {
         t.appendCommand(c.name, &c);

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -115,6 +115,7 @@ static RPCHelpMan getpeerinfo()
                         {RPCResult::Type::STR, "SERVICE_NAME", "the service name if it is recognised"}
                     }},
                     {RPCResult::Type::BOOL, "relaytxes", "Whether we relay transactions to this peer"},
+                    {RPCResult::Type::BOOL, "relaytxpackages", "Whether we relay packages with this peer"},
                     {RPCResult::Type::NUM_TIME, "lastsend", "The " + UNIX_EPOCH_TIME + " of the last send"},
                     {RPCResult::Type::NUM_TIME, "lastrecv", "The " + UNIX_EPOCH_TIME + " of the last receive"},
                     {RPCResult::Type::NUM_TIME, "last_transaction", "The " + UNIX_EPOCH_TIME + " of the last valid transaction received from this peer"},
@@ -243,6 +244,7 @@ static RPCHelpMan getpeerinfo()
             heights.push_back(height);
         }
         obj.pushKV("inflight", heights);
+        obj.pushKV("relaytxpackages", statestats.m_package_relay);
         obj.pushKV("addr_relay_enabled", statestats.m_addr_relay_enabled);
         obj.pushKV("addr_processed", statestats.m_addr_processed);
         obj.pushKV("addr_rate_limited", statestats.m_addr_rate_limited);

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
     NodeId id{0};
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman);
     auto peerLogic = PeerManager::make(*connman, *m_node.addrman, nullptr,
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, *m_node.mempool, false, false);
 
     constexpr int max_outbound_full_relay = MAX_OUTBOUND_FULL_RELAY_CONNECTIONS;
     CConnman::Options options;
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(block_relay_only_eviction)
     NodeId id{0};
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman);
     auto peerLogic = PeerManager::make(*connman, *m_node.addrman, nullptr,
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, *m_node.mempool, false, false);
 
     constexpr int max_outbound_block_relay{MAX_BLOCK_RELAY_ONLY_CONNECTIONS};
     constexpr int64_t MINIMUM_CONNECT_TIME{30};
@@ -273,7 +273,7 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
     auto banman = std::make_unique<BanMan>(m_args.GetDataDirBase() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman);
     auto peerLogic = PeerManager::make(*connman, *m_node.addrman, banman.get(),
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, *m_node.mempool, false, false);
 
     CNetAddr tor_netaddr;
     BOOST_REQUIRE(
@@ -376,7 +376,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     auto banman = std::make_unique<BanMan>(m_args.GetDataDirBase() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     auto connman = std::make_unique<CConnman>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman);
     auto peerLogic = PeerManager::make(*connman, *m_node.addrman, banman.get(),
-                                       *m_node.chainman, *m_node.mempool, false);
+                                       *m_node.chainman, *m_node.mempool, false, false);
 
     banman->ClearBanned();
     int64_t nStartTime = GetTime();

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -668,10 +668,13 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
         const auto submit_cpfp_deprio = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
                                                    package_cpfp, /*test_accept=*/ false);
-        BOOST_CHECK_EQUAL(submit_cpfp_deprio.m_state.GetResult(), PackageValidationResult::PCKG_POLICY);
-        BOOST_CHECK_MESSAGE(submit_cpfp_deprio.m_state.IsInvalid(),
-                            "Package validation unexpectedly succeeded: " << submit_cpfp_deprio.m_state.GetRejectReason());
-        BOOST_CHECK(submit_cpfp_deprio.m_tx_results.empty());
+        BOOST_CHECK_EQUAL(submit_cpfp_deprio.m_state.GetResult(), PackageValidationResult::PCKG_TX);
+        BOOST_CHECK(submit_cpfp_deprio.m_state.IsInvalid());
+        BOOST_CHECK_EQUAL(submit_cpfp_deprio.m_tx_results.find(tx_parent->GetWitnessHash())->second.m_state.GetResult(),
+                          TxValidationResult::TX_MEMPOOL_POLICY);
+        BOOST_CHECK_EQUAL(submit_cpfp_deprio.m_tx_results.find(tx_child->GetWitnessHash())->second.m_state.GetResult(),
+                          TxValidationResult::TX_MISSING_INPUTS);
+        BOOST_CHECK(submit_cpfp_deprio.m_tx_results.find(tx_parent->GetWitnessHash())->second.m_state.GetRejectReason() == "min relay fee not met");
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
         const CFeeRate expected_feerate(0, GetVirtualTransactionSize(*tx_parent) + GetVirtualTransactionSize(*tx_child));
     }
@@ -805,8 +808,8 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
         BOOST_CHECK_MESSAGE(submit_rich_parent.m_state.IsInvalid(), "Package validation unexpectedly succeeded");
 
         // The child would have been validated on its own and failed, then submitted as a "package" of 1.
-        BOOST_CHECK_EQUAL(submit_rich_parent.m_state.GetResult(), PackageValidationResult::PCKG_POLICY);
-        BOOST_CHECK_EQUAL(submit_rich_parent.m_state.GetRejectReason(), "package-fee-too-low");
+        BOOST_CHECK_EQUAL(submit_rich_parent.m_state.GetResult(), PackageValidationResult::PCKG_TX);
+        BOOST_CHECK_EQUAL(submit_rich_parent.m_state.GetRejectReason(), "transaction failed");
 
         auto it_parent = submit_rich_parent.m_tx_results.find(tx_parent_rich->GetWitnessHash());
         BOOST_CHECK(it_parent != submit_rich_parent.m_tx_results.end());
@@ -815,6 +818,11 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
         BOOST_CHECK_MESSAGE(it_parent->second.m_base_fees.value() == high_parent_fee,
                 strprintf("rich parent: expected fee %s, got %s", high_parent_fee, it_parent->second.m_base_fees.value()));
         BOOST_CHECK(it_parent->second.m_effective_feerate == CFeeRate(high_parent_fee, GetVirtualTransactionSize(*tx_parent_rich)));
+        auto it_child = submit_rich_parent.m_tx_results.find(tx_child_poor->GetWitnessHash());
+        BOOST_CHECK(it_child != submit_rich_parent.m_tx_results.end());
+        BOOST_CHECK_EQUAL(it_child->second.m_result_type, MempoolAcceptResult::ResultType::INVALID);
+        BOOST_CHECK_EQUAL(it_child->second.m_state.GetResult(), TxValidationResult::TX_MEMPOOL_POLICY);
+        BOOST_CHECK(it_child->second.m_state.GetRejectReason() == "min relay fee not met");
 
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
         BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(tx_parent_rich->GetHash())));

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -807,18 +807,20 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
         expected_pool_size += 1;
         BOOST_CHECK_MESSAGE(submit_rich_parent.m_state.IsInvalid(), "Package validation unexpectedly succeeded");
 
-        // The child would have been validated on its own and failed, then submitted as a "package" of 1.
+        // The child would have been validated on its own and failed.
         BOOST_CHECK_EQUAL(submit_rich_parent.m_state.GetResult(), PackageValidationResult::PCKG_TX);
         BOOST_CHECK_EQUAL(submit_rich_parent.m_state.GetRejectReason(), "transaction failed");
 
         auto it_parent = submit_rich_parent.m_tx_results.find(tx_parent_rich->GetWitnessHash());
+        auto it_child = submit_rich_parent.m_tx_results.find(tx_child_poor->GetWitnessHash());
         BOOST_CHECK(it_parent != submit_rich_parent.m_tx_results.end());
+        BOOST_CHECK(it_child != submit_rich_parent.m_tx_results.end());
         BOOST_CHECK(it_parent->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
+        BOOST_CHECK(it_child->second.m_result_type == MempoolAcceptResult::ResultType::INVALID);
         BOOST_CHECK(it_parent->second.m_state.GetRejectReason() == "");
         BOOST_CHECK_MESSAGE(it_parent->second.m_base_fees.value() == high_parent_fee,
                 strprintf("rich parent: expected fee %s, got %s", high_parent_fee, it_parent->second.m_base_fees.value()));
         BOOST_CHECK(it_parent->second.m_effective_feerate == CFeeRate(high_parent_fee, GetVirtualTransactionSize(*tx_parent_rich)));
-        auto it_child = submit_rich_parent.m_tx_results.find(tx_child_poor->GetWitnessHash());
         BOOST_CHECK(it_child != submit_rich_parent.m_tx_results.end());
         BOOST_CHECK_EQUAL(it_child->second.m_result_type, MempoolAcceptResult::ResultType::INVALID);
         BOOST_CHECK_EQUAL(it_child->second.m_state.GetResult(), TxValidationResult::TX_MEMPOOL_POLICY);

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -353,6 +353,8 @@ BOOST_FIXTURE_TEST_CASE(noncontextual_package_tests, TestChain100Setup)
 
 BOOST_FIXTURE_TEST_CASE(package_submission_tests, TestChain100Setup)
 {
+    // Make coinbases 0 and 1 mature/spendable.
+    mineBlocks(1);
     LOCK(cs_main);
     unsigned int expected_pool_size = m_node.mempool->size();
     CKey parent_key;
@@ -439,6 +441,55 @@ BOOST_FIXTURE_TEST_CASE(package_submission_tests, TestChain100Setup)
         BOOST_CHECK_EQUAL(it_parent->second.m_state.GetRejectReason(), "bad-witness-nonstandard");
         BOOST_CHECK_EQUAL(it_child->second.m_state.GetResult(), TxValidationResult::TX_MISSING_INPUTS);
         BOOST_CHECK_EQUAL(it_child->second.m_state.GetRejectReason(), "bad-txns-inputs-missingorspent");
+    }
+
+    // Check that validation isn't quitting *too* early.
+    // This package has a child with 2 parents. Parent1 has a consensus issue, while Parent2 is
+    // valid and has a high feerate (can be accepted by itself). Parent1 and the child would be
+    // rejected, and Parent2 should be accepted. Otherwise, anybody could censor a transaction like
+    // Parent2 by broadcasting it in a package similar to this one.
+    {
+        // premature coinbase spend (consensus error)
+        auto tx_parent1_bad{MakeTransactionRef(CreateValidMempoolTransaction(/*input_transaction=*/m_coinbase_txns[99],
+                                                                             /*input_vout=*/0,
+                                                                             /*input_height=*/102,
+                                                                             /*input_signing_key=*/coinbaseKey,
+                                                                             /*output_destination=*/parent_locking_script,
+                                                                             /*output_amount=*/ 24 * COIN,
+                                                                             /*submit=*/false))};
+        auto tx_parent2_good{MakeTransactionRef(CreateValidMempoolTransaction(/*input_transaction=*/m_coinbase_txns[1],
+                                                                             /*input_vout=*/0,
+                                                                             /*input_height=*/102,
+                                                                             /*input_signing_key=*/coinbaseKey,
+                                                                             /*output_destination=*/parent_locking_script,
+                                                                             /*output_amount=*/ 24 * COIN,
+                                                                             /*submit=*/false))};
+        auto tx_child_quit_early{MakeTransactionRef(CreateValidMempoolTransaction(/*input_transactions=*/{tx_parent1_bad, tx_parent2_good},
+                                                                                  /*inputs=*/{COutPoint{tx_parent1_bad->GetHash(), 0},
+                                                                                              COutPoint{tx_parent2_good->GetHash(), 0}},
+                                                                                  /*input_height=*/102,
+                                                                                  /*input_signing_keys=*/{parent_key},
+                                                                                  /*outputs=*/{CTxOut{23*COIN, child_locking_script}},
+                                                                                  /*submit=*/false))};
+        Package package_quit_too_early{tx_parent1_bad, tx_parent2_good, tx_child_quit_early};
+        auto result_quit_too_early = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                       package_quit_too_early, /*test_accept=*/ false);
+        expected_pool_size += 1;
+        BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
+        BOOST_CHECK(result_quit_too_early.m_state.IsInvalid());
+        BOOST_CHECK_EQUAL(result_quit_too_early.m_state.GetResult(), PackageValidationResult::PCKG_TX);
+        BOOST_CHECK_EQUAL(result_quit_too_early.m_tx_results.size(), 3);
+        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(tx_parent2_good->GetHash())));
+        BOOST_CHECK(!m_node.mempool->exists(GenTxid::Txid(tx_parent1_bad->GetHash())));
+        BOOST_CHECK(!m_node.mempool->exists(GenTxid::Txid(tx_child_quit_early->GetHash())));
+        auto it_parent1 = result_quit_too_early.m_tx_results.find(tx_parent1_bad->GetWitnessHash());
+        auto it_parent2 = result_quit_too_early.m_tx_results.find(tx_parent2_good->GetWitnessHash());
+        auto it_child = result_quit_too_early.m_tx_results.find(tx_child_quit_early->GetWitnessHash());
+        BOOST_CHECK(it_parent1->second.m_state.IsInvalid());
+        BOOST_CHECK_EQUAL(it_parent1->second.m_state.GetResult(), TxValidationResult::TX_PREMATURE_SPEND);
+        BOOST_CHECK_MESSAGE(it_parent2->second.m_state.IsValid(), "parent2 error: " << it_parent2->second.m_state.GetRejectReason());
+        BOOST_CHECK(it_child->second.m_state.IsInvalid());
+        BOOST_CHECK_EQUAL(it_child->second.m_state.GetResult(), TxValidationResult::TX_MISSING_INPUTS);
     }
 
     // Child with missing parent.

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -69,7 +69,7 @@ BOOST_FIXTURE_TEST_CASE(package_sanitization_tests, TestChain100Setup)
         package_too_many.emplace_back(create_placeholder_tx(1, 1));
     }
     PackageValidationState state_too_many;
-    BOOST_CHECK(!IsPackageWellFormed(package_too_many, state_too_many));
+    BOOST_CHECK(!IsPackageWellFormed(package_too_many, state_too_many, /*require_sorted=*/true));
     BOOST_CHECK_EQUAL(state_too_many.GetResult(), PackageValidationResult::PCKG_POLICY);
     BOOST_CHECK_EQUAL(state_too_many.GetRejectReason(), "package-too-many-transactions");
 
@@ -84,7 +84,7 @@ BOOST_FIXTURE_TEST_CASE(package_sanitization_tests, TestChain100Setup)
     }
     BOOST_CHECK(package_too_large.size() <= MAX_PACKAGE_COUNT);
     PackageValidationState state_too_large;
-    BOOST_CHECK(!IsPackageWellFormed(package_too_large, state_too_large));
+    BOOST_CHECK(!IsPackageWellFormed(package_too_large, state_too_large, /*require_sorted=*/true));
     BOOST_CHECK_EQUAL(state_too_large.GetResult(), PackageValidationResult::PCKG_POLICY);
     BOOST_CHECK_EQUAL(state_too_large.GetRejectReason(), "package-too-large");
 }
@@ -279,8 +279,8 @@ BOOST_FIXTURE_TEST_CASE(noncontextual_package_tests, TestChain100Setup)
         CTransactionRef tx_child = MakeTransactionRef(mtx_child);
 
         PackageValidationState state;
-        BOOST_CHECK(IsPackageWellFormed({tx_parent, tx_child}, state));
-        BOOST_CHECK(!IsPackageWellFormed({tx_child, tx_parent}, state));
+        BOOST_CHECK(IsPackageWellFormed({tx_parent, tx_child}, state, /*require_sorted=*/true));
+        BOOST_CHECK(!IsPackageWellFormed({tx_child, tx_parent}, state, /*require_sorted=*/true));
         BOOST_CHECK_EQUAL(state.GetResult(), PackageValidationResult::PCKG_POLICY);
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "package-not-sorted");
         BOOST_CHECK(IsChildWithParents({tx_parent, tx_child}));
@@ -307,7 +307,7 @@ BOOST_FIXTURE_TEST_CASE(noncontextual_package_tests, TestChain100Setup)
         package.push_back(MakeTransactionRef(child));
 
         PackageValidationState state;
-        BOOST_CHECK(IsPackageWellFormed(package, state));
+        BOOST_CHECK(IsPackageWellFormed(package, state, /*require_sorted=*/true));
         BOOST_CHECK(IsChildWithParents(package));
 
         package.erase(package.begin());
@@ -344,8 +344,8 @@ BOOST_FIXTURE_TEST_CASE(noncontextual_package_tests, TestChain100Setup)
         // IsChildWithParents does not detect unsorted parents.
         BOOST_CHECK(IsChildWithParents({tx_parent_also_child, tx_parent, tx_child}));
         BOOST_CHECK(!IsSorted({tx_parent_also_child, tx_parent, tx_child}));
-        BOOST_CHECK(IsPackageWellFormed({tx_parent, tx_parent_also_child, tx_child}, state));
-        BOOST_CHECK(!IsPackageWellFormed({tx_parent_also_child, tx_parent, tx_child}, state));
+        BOOST_CHECK(IsPackageWellFormed({tx_parent, tx_parent_also_child, tx_child}, state, /*require_sorted=*/true));
+        BOOST_CHECK(!IsPackageWellFormed({tx_parent_also_child, tx_parent, tx_child}, state, /*require_sorted=*/true));
         BOOST_CHECK_EQUAL(state.GetResult(), PackageValidationResult::PCKG_POLICY);
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "package-not-sorted");
     }
@@ -374,7 +374,7 @@ BOOST_FIXTURE_TEST_CASE(package_submission_tests, TestChain100Setup)
                                                      package_unrelated, /*test_accept=*/false);
     BOOST_CHECK(result_unrelated_submit.m_state.IsInvalid());
     BOOST_CHECK_EQUAL(result_unrelated_submit.m_state.GetResult(), PackageValidationResult::PCKG_POLICY);
-    BOOST_CHECK_EQUAL(result_unrelated_submit.m_state.GetRejectReason(), "package-not-child-with-parents");
+    BOOST_CHECK_EQUAL(result_unrelated_submit.m_state.GetRejectReason(), "not-ancestor-package");
     BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
 
     // Parent and Child (and Grandchild) Package
@@ -408,16 +408,6 @@ BOOST_FIXTURE_TEST_CASE(package_submission_tests, TestChain100Setup)
                                                        /*output_amount=*/CAmount(47 * COIN), /*submit=*/false);
     CTransactionRef tx_grandchild = MakeTransactionRef(mtx_grandchild);
     package_3gen.push_back(tx_grandchild);
-
-    // 3 Generations is not allowed.
-    {
-        auto result_3gen_submit = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                    package_3gen, /*test_accept=*/false);
-        BOOST_CHECK(result_3gen_submit.m_state.IsInvalid());
-        BOOST_CHECK_EQUAL(result_3gen_submit.m_state.GetResult(), PackageValidationResult::PCKG_POLICY);
-        BOOST_CHECK_EQUAL(result_3gen_submit.m_state.GetRejectReason(), "package-not-child-with-parents");
-        BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
-    }
 
     // Parent and child package where transactions are invalid for reasons other than fee and
     // missing inputs, so the package validation isn't expected to happen.
@@ -492,44 +482,37 @@ BOOST_FIXTURE_TEST_CASE(package_submission_tests, TestChain100Setup)
         BOOST_CHECK_EQUAL(it_child->second.m_state.GetResult(), TxValidationResult::TX_MISSING_INPUTS);
     }
 
-    // Child with missing parent.
-    mtx_child.vin.push_back(CTxIn(COutPoint(package_unrelated[0]->GetHash(), 0)));
-    Package package_missing_parent;
-    package_missing_parent.push_back(tx_parent);
-    package_missing_parent.push_back(MakeTransactionRef(mtx_child));
+    // Submit package parent + child + grandchild.
     {
-        const auto result_missing_parent = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                             package_missing_parent, /*test_accept=*/false);
-        BOOST_CHECK(result_missing_parent.m_state.IsInvalid());
-        BOOST_CHECK_EQUAL(result_missing_parent.m_state.GetResult(), PackageValidationResult::PCKG_POLICY);
-        BOOST_CHECK_EQUAL(result_missing_parent.m_state.GetRejectReason(), "package-not-child-with-unconfirmed-parents");
-        BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
-    }
-
-    // Submit package with parent + child.
-    {
-        const auto submit_parent_child = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
-                                                           package_parent_child, /*test_accept=*/false);
-        expected_pool_size += 2;
-        BOOST_CHECK_MESSAGE(submit_parent_child.m_state.IsValid(),
-                            "Package validation unexpectedly failed: " << submit_parent_child.m_state.GetRejectReason());
-        BOOST_CHECK_EQUAL(submit_parent_child.m_tx_results.size(), package_parent_child.size());
-        auto it_parent = submit_parent_child.m_tx_results.find(tx_parent->GetWitnessHash());
-        auto it_child = submit_parent_child.m_tx_results.find(tx_child->GetWitnessHash());
-        BOOST_CHECK(it_parent != submit_parent_child.m_tx_results.end());
+        auto result_3gen_submit = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
+                                                    package_3gen, /*test_accept=*/false);
+        expected_pool_size += 3;
+        BOOST_CHECK_MESSAGE(result_3gen_submit.m_state.IsValid(),
+                            "Package validation unexpectedly failed: " << result_3gen_submit.m_state.GetRejectReason());
+        BOOST_CHECK_EQUAL(result_3gen_submit.m_tx_results.size(), package_3gen.size());
+        auto it_parent = result_3gen_submit.m_tx_results.find(tx_parent->GetWitnessHash());
+        auto it_child = result_3gen_submit.m_tx_results.find(tx_child->GetWitnessHash());
+        auto it_grandchild = result_3gen_submit.m_tx_results.find(tx_grandchild->GetWitnessHash());
+        BOOST_CHECK(it_parent != result_3gen_submit.m_tx_results.end());
         BOOST_CHECK(it_parent->second.m_state.IsValid());
         BOOST_CHECK(it_parent->second.m_effective_feerate == CFeeRate(1 * COIN, GetVirtualTransactionSize(*tx_parent)));
         BOOST_CHECK_EQUAL(it_parent->second.m_wtxids_fee_calculations.value().size(), 1);
         BOOST_CHECK_EQUAL(it_parent->second.m_wtxids_fee_calculations.value().front(), tx_parent->GetWitnessHash());
-        BOOST_CHECK(it_child != submit_parent_child.m_tx_results.end());
+        BOOST_CHECK(it_child != result_3gen_submit.m_tx_results.end());
         BOOST_CHECK(it_child->second.m_state.IsValid());
         BOOST_CHECK(it_child->second.m_effective_feerate == CFeeRate(1 * COIN, GetVirtualTransactionSize(*tx_child)));
         BOOST_CHECK_EQUAL(it_child->second.m_wtxids_fee_calculations.value().size(), 1);
         BOOST_CHECK_EQUAL(it_child->second.m_wtxids_fee_calculations.value().front(), tx_child->GetWitnessHash());
+        BOOST_CHECK(it_grandchild != result_3gen_submit.m_tx_results.end());
+        BOOST_CHECK(it_grandchild->second.m_state.IsValid());
+        BOOST_CHECK(it_grandchild->second.m_effective_feerate == CFeeRate(1 * COIN, GetVirtualTransactionSize(*tx_grandchild)));
+        BOOST_CHECK_EQUAL(it_grandchild->second.m_wtxids_fee_calculations.value().size(), 1);
+        BOOST_CHECK_EQUAL(it_grandchild->second.m_wtxids_fee_calculations.value().front(), tx_grandchild->GetWitnessHash());
 
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
         BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(tx_parent->GetHash())));
         BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(tx_child->GetHash())));
+        BOOST_CHECK(m_node.mempool->exists(GenTxid::Txid(tx_grandchild->GetHash())));
     }
 
     // Already-in-mempool transactions should be detected and de-duplicated.

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -857,7 +857,7 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
         BOOST_CHECK_EQUAL(submit_cpfp_deprio.m_state.GetResult(), PackageValidationResult::PCKG_TX);
         BOOST_CHECK(submit_cpfp_deprio.m_state.IsInvalid());
         BOOST_CHECK_EQUAL(submit_cpfp_deprio.m_tx_results.find(tx_parent->GetWitnessHash())->second.m_state.GetResult(),
-                          TxValidationResult::TX_MEMPOOL_POLICY);
+                          TxValidationResult::TX_LOW_FEE);
         BOOST_CHECK_EQUAL(submit_cpfp_deprio.m_tx_results.find(tx_child->GetWitnessHash())->second.m_state.GetResult(),
                           TxValidationResult::TX_MISSING_INPUTS);
         BOOST_CHECK(submit_cpfp_deprio.m_tx_results.find(tx_parent->GetWitnessHash())->second.m_state.GetRejectReason() == "min relay fee not met");
@@ -1009,7 +1009,7 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
         BOOST_CHECK(it_parent->second.m_effective_feerate == CFeeRate(high_parent_fee, GetVirtualTransactionSize(*tx_parent_rich)));
         BOOST_CHECK(it_child != submit_rich_parent.m_tx_results.end());
         BOOST_CHECK_EQUAL(it_child->second.m_result_type, MempoolAcceptResult::ResultType::INVALID);
-        BOOST_CHECK_EQUAL(it_child->second.m_state.GetResult(), TxValidationResult::TX_MEMPOOL_POLICY);
+        BOOST_CHECK_EQUAL(it_child->second.m_state.GetResult(), TxValidationResult::TX_LOW_FEE);
         BOOST_CHECK(it_child->second.m_state.GetRejectReason() == "min relay fee not met");
 
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -284,16 +284,27 @@ BOOST_FIXTURE_TEST_CASE(noncontextual_package_tests, TestChain100Setup)
         BOOST_CHECK_EQUAL(state.GetResult(), PackageValidationResult::PCKG_POLICY);
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "package-not-sorted");
         BOOST_CHECK(IsChildWithParents({tx_parent, tx_child}));
+        BOOST_CHECK_EQUAL(GetPackageHash({tx_child}), GetCombinedHash({tx_child->GetWitnessHash()}));
+        BOOST_CHECK_EQUAL(GetPackageHash({tx_child, tx_parent}), GetPackageHash({tx_parent, tx_child}));
+        BOOST_CHECK_EQUAL(GetCombinedHash({tx_parent->GetWitnessHash(), tx_child->GetWitnessHash()}),
+                          GetCombinedHash({tx_child->GetWitnessHash(), tx_parent->GetWitnessHash()}));
+        BOOST_CHECK_EQUAL(GetCombinedHash({tx_parent->GetWitnessHash(), tx_child->GetWitnessHash()}),
+                          GetPackageHash({tx_parent, tx_child}));
+        BOOST_CHECK(GetPackageHash({tx_parent}) != GetPackageHash({tx_child}));
+        BOOST_CHECK(GetPackageHash({tx_child, tx_child}) != GetPackageHash({tx_child}));
+        BOOST_CHECK(GetPackageHash({tx_child, tx_parent}) != GetPackageHash({tx_child, tx_child}));
     }
 
     // 24 Parents and 1 Child
     {
         Package package;
+        std::vector<uint256> package_wtxids;
         CMutableTransaction child;
         for (int i{0}; i < 24; ++i) {
             auto parent = MakeTransactionRef(CreateValidMempoolTransaction(m_coinbase_txns[i + 1],
                                              0, 0, coinbaseKey, spk, CAmount(48 * COIN), false));
             package.emplace_back(parent);
+            package_wtxids.emplace_back(parent->GetWitnessHash());
             child.vin.push_back(CTxIn(COutPoint(parent->GetHash(), 0)));
         }
         child.vout.push_back(CTxOut(47 * COIN, spk2));
@@ -304,7 +315,10 @@ BOOST_FIXTURE_TEST_CASE(noncontextual_package_tests, TestChain100Setup)
         // The parents can be in any order.
         FastRandomContext rng;
         Shuffle(package.begin(), package.end(), rng);
-        package.push_back(MakeTransactionRef(child));
+        auto tx_child = MakeTransactionRef(child);
+        package.emplace_back(tx_child);
+        package_wtxids.push_back(tx_child->GetWitnessHash());
+        BOOST_CHECK_EQUAL(GetCombinedHash(package_wtxids), GetPackageHash(package));
 
         PackageValidationState state;
         BOOST_CHECK(IsPackageWellFormed(package, state, /*require_sorted=*/true));
@@ -589,6 +603,8 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
     BOOST_CHECK_EQUAL(ptx_child1->GetHash(), ptx_child2->GetHash());
     // child1 and child2 have different wtxids
     BOOST_CHECK(ptx_child1->GetWitnessHash() != ptx_child2->GetWitnessHash());
+    // package1 and package2 have different packageids
+    BOOST_CHECK(GetPackageHash({ptx_parent, ptx_child1}) != GetPackageHash({ptx_parent, ptx_child2}));
 
     // Try submitting Package1{parent, child1} and Package2{parent, child2} where the children are
     // same-txid-different-witness.
@@ -655,7 +671,7 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
                                                         /*output_destination=*/grandchild_locking_script,
                                                         /*output_amount=*/CAmount(47 * COIN), /*submit=*/false);
     CTransactionRef ptx_grandchild = MakeTransactionRef(mtx_grandchild);
-
+    BOOST_CHECK(GetPackageHash({ptx_child1, ptx_grandchild}) != GetPackageHash({ptx_child2, ptx_grandchild}));
     // We already submitted child1 above.
     {
         const auto submit_spend_ignored = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -373,6 +373,7 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
 {
     // Mine blocks to mature coinbases.
     mineBlocks(5);
+    MockMempoolMinFee(CFeeRate(5000));
     LOCK(cs_main);
 
     // Transactions with a same-txid-different-witness transaction in the mempool should be ignored,
@@ -560,13 +561,15 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
     BOOST_CHECK(parent2_v2_result.m_result_type == MempoolAcceptResult::ResultType::VALID);
     package_mixed.push_back(ptx_parent2_v1);
 
-    // parent3 will be a new transaction. Put 0 fees on it to make it invalid on its own.
+    // parent3 will be a new transaction. Put a low feerate to make it invalid on its own.
     auto mtx_parent3 = CreateValidMempoolTransaction(/*input_transaction=*/m_coinbase_txns[3], /*input_vout=*/0,
                                                      /*input_height=*/0, /*input_signing_key=*/coinbaseKey,
                                                      /*output_destination=*/acs_spk,
-                                                     /*output_amount=*/CAmount(50 * COIN), /*submit=*/false);
+                                                     /*output_amount=*/CAmount(50 * COIN - 200), /*submit=*/false);
     CTransactionRef ptx_parent3 = MakeTransactionRef(mtx_parent3);
     package_mixed.push_back(ptx_parent3);
+    BOOST_CHECK(m_node.mempool->GetMinFee().GetFee(GetVirtualTransactionSize(*ptx_parent3)) > 200);
+    BOOST_CHECK(m_node.mempool->m_min_relay_feerate.GetFee(GetVirtualTransactionSize(*ptx_parent3)) <= 200);
 
     // child spends parent1, parent2, and parent3
     CKey mixed_grandchild_key;
@@ -627,6 +630,7 @@ BOOST_FIXTURE_TEST_CASE(package_witness_swap_tests, TestChain100Setup)
 BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
 {
     mineBlocks(5);
+    MockMempoolMinFee(CFeeRate(5000));
     LOCK(::cs_main);
     size_t expected_pool_size = m_node.mempool->size();
     CKey child_key;
@@ -636,9 +640,9 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
     grandchild_key.MakeNewKey(true);
     CScript child_spk = GetScriptForDestination(WitnessV0KeyHash(grandchild_key.GetPubKey()));
 
-    // zero-fee parent and high-fee child package
+    // low-fee parent and high-fee child package
     const CAmount coinbase_value{50 * COIN};
-    const CAmount parent_value{coinbase_value - 0};
+    const CAmount parent_value{coinbase_value - 200};
     const CAmount child_value{parent_value - COIN};
 
     Package package_cpfp;
@@ -657,9 +661,9 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
     package_cpfp.push_back(tx_child);
 
     // Package feerate is calculated using modified fees, and prioritisetransaction accepts negative
-    // fee deltas. This should be taken into account. De-prioritise the parent transaction by -1BTC,
-    // bringing the package feerate to 0.
-    m_node.mempool->PrioritiseTransaction(tx_parent->GetHash(), -1 * COIN);
+    // fee deltas. This should be taken into account. De-prioritise the parent transaction
+    // to bring the package feerate to 0.
+    m_node.mempool->PrioritiseTransaction(tx_parent->GetHash(), child_value - coinbase_value);
     {
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
         const auto submit_cpfp_deprio = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
@@ -675,8 +679,8 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
     // Clear the prioritisation of the parent transaction.
     WITH_LOCK(m_node.mempool->cs, m_node.mempool->ClearPrioritisation(tx_parent->GetHash()));
 
-    // Package CPFP: Even though the parent pays 0 absolute fees, the child pays 1 BTC which is
-    // enough for the package feerate to meet the threshold.
+    // Package CPFP: Even though the parent's feerate is below the mempool minimum feerate, the
+    // child pays enough for the package feerate to meet the threshold.
     {
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
         const auto submit_cpfp = ProcessNewPackage(m_node.chainman->ActiveChainstate(), *m_node.mempool,
@@ -689,7 +693,7 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
         auto it_child = submit_cpfp.m_tx_results.find(tx_child->GetWitnessHash());
         BOOST_CHECK(it_parent != submit_cpfp.m_tx_results.end());
         BOOST_CHECK(it_parent->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
-        BOOST_CHECK(it_parent->second.m_base_fees.value() == 0);
+        BOOST_CHECK(it_parent->second.m_base_fees.value() == coinbase_value - parent_value);
         BOOST_CHECK(it_child != submit_cpfp.m_tx_results.end());
         BOOST_CHECK(it_child->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
         BOOST_CHECK(it_child->second.m_base_fees.value() == COIN);
@@ -709,22 +713,28 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
     }
 
     // Just because we allow low-fee parents doesn't mean we allow low-feerate packages.
-    // This package just pays 200 satoshis total. This would be enough to pay for the child alone,
-    // but isn't enough for the entire package to meet the 1sat/vbyte minimum.
+    // The mempool minimum feerate is 5sat/vB, but this package just pays 800 satoshis total.
+    // The child fees would be able to pay for itself, but isn't enough for the entire package.
     Package package_still_too_low;
+    const CAmount parent_fee{200};
+    const CAmount child_fee{600};
     auto mtx_parent_cheap = CreateValidMempoolTransaction(/*input_transaction=*/m_coinbase_txns[1], /*input_vout=*/0,
                                                           /*input_height=*/0, /*input_signing_key=*/coinbaseKey,
                                                           /*output_destination=*/parent_spk,
-                                                          /*output_amount=*/coinbase_value, /*submit=*/false);
+                                                          /*output_amount=*/coinbase_value - parent_fee, /*submit=*/false);
     CTransactionRef tx_parent_cheap = MakeTransactionRef(mtx_parent_cheap);
     package_still_too_low.push_back(tx_parent_cheap);
+    BOOST_CHECK(m_node.mempool->GetMinFee().GetFee(GetVirtualTransactionSize(*tx_parent_cheap)) > parent_fee);
+    BOOST_CHECK(m_node.mempool->m_min_relay_feerate.GetFee(GetVirtualTransactionSize(*tx_parent_cheap)) <= parent_fee);
 
     auto mtx_child_cheap = CreateValidMempoolTransaction(/*input_transaction=*/tx_parent_cheap, /*input_vout=*/0,
                                                          /*input_height=*/101, /*input_signing_key=*/child_key,
                                                          /*output_destination=*/child_spk,
-                                                         /*output_amount=*/coinbase_value - 200, /*submit=*/false);
+                                                         /*output_amount=*/coinbase_value - parent_fee - child_fee, /*submit=*/false);
     CTransactionRef tx_child_cheap = MakeTransactionRef(mtx_child_cheap);
     package_still_too_low.push_back(tx_child_cheap);
+    BOOST_CHECK(m_node.mempool->GetMinFee().GetFee(GetVirtualTransactionSize(*tx_child_cheap)) <= child_fee);
+    BOOST_CHECK(m_node.mempool->GetMinFee().GetFee(GetVirtualTransactionSize(*tx_parent_cheap) + GetVirtualTransactionSize(*tx_child_cheap)) > parent_fee + child_fee);
 
     // Cheap package should fail with package-fee-too-low.
     {
@@ -735,11 +745,6 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
         BOOST_CHECK_EQUAL(submit_package_too_low.m_state.GetResult(), PackageValidationResult::PCKG_POLICY);
         BOOST_CHECK_EQUAL(submit_package_too_low.m_state.GetRejectReason(), "package-fee-too-low");
         BOOST_CHECK_EQUAL(m_node.mempool->size(), expected_pool_size);
-        const CFeeRate child_feerate(200, GetVirtualTransactionSize(*tx_child_cheap));
-        BOOST_CHECK(child_feerate.GetFeePerK() > 1000);
-        const CFeeRate expected_feerate(200,
-            GetVirtualTransactionSize(*tx_parent_cheap) + GetVirtualTransactionSize(*tx_child_cheap));
-        BOOST_CHECK(expected_feerate.GetFeePerK() < 1000);
     }
 
     // Package feerate includes the modified fees of the transactions.
@@ -752,18 +757,18 @@ BOOST_FIXTURE_TEST_CASE(package_cpfp_tests, TestChain100Setup)
         expected_pool_size += 2;
         BOOST_CHECK_MESSAGE(submit_prioritised_package.m_state.IsValid(),
                 "Package validation unexpectedly failed" << submit_prioritised_package.m_state.GetRejectReason());
-        const CFeeRate expected_feerate(1 * COIN + 200,
+        const CFeeRate expected_feerate(1 * COIN + 800,
             GetVirtualTransactionSize(*tx_parent_cheap) + GetVirtualTransactionSize(*tx_child_cheap));
         BOOST_CHECK_EQUAL(submit_prioritised_package.m_tx_results.size(), package_still_too_low.size());
         auto it_parent = submit_prioritised_package.m_tx_results.find(tx_parent_cheap->GetWitnessHash());
         auto it_child = submit_prioritised_package.m_tx_results.find(tx_child_cheap->GetWitnessHash());
         BOOST_CHECK(it_parent != submit_prioritised_package.m_tx_results.end());
         BOOST_CHECK(it_parent->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
-        BOOST_CHECK(it_parent->second.m_base_fees.value() == 0);
+        BOOST_CHECK(it_parent->second.m_base_fees.value() == 200);
         BOOST_CHECK(it_parent->second.m_effective_feerate.value() == expected_feerate);
         BOOST_CHECK(it_child != submit_prioritised_package.m_tx_results.end());
         BOOST_CHECK(it_child->second.m_result_type == MempoolAcceptResult::ResultType::VALID);
-        BOOST_CHECK(it_child->second.m_base_fees.value() == 200);
+        BOOST_CHECK(it_child->second.m_base_fees.value() == 600);
         BOOST_CHECK(it_child->second.m_effective_feerate.value() == expected_feerate);
         std::vector<uint256> expected_wtxids({tx_parent_cheap->GetWitnessHash(), tx_child_cheap->GetWitnessHash()});
         BOOST_CHECK(it_parent->second.m_wtxids_fee_calculations.value() == expected_wtxids);

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -45,7 +45,7 @@ BOOST_FIXTURE_TEST_CASE(package_sanitization_tests, TestChain100Setup)
         package_too_many.emplace_back(create_placeholder_tx(1, 1));
     }
     PackageValidationState state_too_many;
-    BOOST_CHECK(!CheckPackage(package_too_many, state_too_many));
+    BOOST_CHECK(!IsPackageWellFormed(package_too_many, state_too_many));
     BOOST_CHECK_EQUAL(state_too_many.GetResult(), PackageValidationResult::PCKG_POLICY);
     BOOST_CHECK_EQUAL(state_too_many.GetRejectReason(), "package-too-many-transactions");
 
@@ -60,7 +60,7 @@ BOOST_FIXTURE_TEST_CASE(package_sanitization_tests, TestChain100Setup)
     }
     BOOST_CHECK(package_too_large.size() <= MAX_PACKAGE_COUNT);
     PackageValidationState state_too_large;
-    BOOST_CHECK(!CheckPackage(package_too_large, state_too_large));
+    BOOST_CHECK(!IsPackageWellFormed(package_too_large, state_too_large));
     BOOST_CHECK_EQUAL(state_too_large.GetResult(), PackageValidationResult::PCKG_POLICY);
     BOOST_CHECK_EQUAL(state_too_large.GetRejectReason(), "package-too-large");
 }
@@ -144,8 +144,8 @@ BOOST_FIXTURE_TEST_CASE(noncontextual_package_tests, TestChain100Setup)
         CTransactionRef tx_child = MakeTransactionRef(mtx_child);
 
         PackageValidationState state;
-        BOOST_CHECK(CheckPackage({tx_parent, tx_child}, state));
-        BOOST_CHECK(!CheckPackage({tx_child, tx_parent}, state));
+        BOOST_CHECK(IsPackageWellFormed({tx_parent, tx_child}, state));
+        BOOST_CHECK(!IsPackageWellFormed({tx_child, tx_parent}, state));
         BOOST_CHECK_EQUAL(state.GetResult(), PackageValidationResult::PCKG_POLICY);
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "package-not-sorted");
         BOOST_CHECK(IsChildWithParents({tx_parent, tx_child}));
@@ -172,7 +172,7 @@ BOOST_FIXTURE_TEST_CASE(noncontextual_package_tests, TestChain100Setup)
         package.push_back(MakeTransactionRef(child));
 
         PackageValidationState state;
-        BOOST_CHECK(CheckPackage(package, state));
+        BOOST_CHECK(IsPackageWellFormed(package, state));
         BOOST_CHECK(IsChildWithParents(package));
 
         package.erase(package.begin());
@@ -208,8 +208,8 @@ BOOST_FIXTURE_TEST_CASE(noncontextual_package_tests, TestChain100Setup)
         BOOST_CHECK(IsChildWithParents({tx_parent, tx_parent_also_child, tx_child}));
         // IsChildWithParents does not detect unsorted parents.
         BOOST_CHECK(IsChildWithParents({tx_parent_also_child, tx_parent, tx_child}));
-        BOOST_CHECK(CheckPackage({tx_parent, tx_parent_also_child, tx_child}, state));
-        BOOST_CHECK(!CheckPackage({tx_parent_also_child, tx_parent, tx_child}, state));
+        BOOST_CHECK(IsPackageWellFormed({tx_parent, tx_parent_also_child, tx_child}, state));
+        BOOST_CHECK(!IsPackageWellFormed({tx_parent_also_child, tx_parent, tx_child}, state));
         BOOST_CHECK_EQUAL(state.GetResult(), PackageValidationResult::PCKG_POLICY);
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "package-not-sorted");
     }

--- a/src/test/txpackage_tests.cpp
+++ b/src/test/txpackage_tests.cpp
@@ -36,6 +36,30 @@ inline CTransactionRef create_placeholder_tx(size_t num_inputs, size_t num_outpu
     return MakeTransactionRef(mtx);
 }
 
+// Context-free check that a package only contains a tx (the last tx in the package) with its
+// ancestors. Not all of the tx's ancestors need to be present.
+bool IsAncestorPackage(const Package& package)
+{
+    if (!IsSorted(package)) return false;
+    if (!IsConsistent(package)) return false;
+    const auto& dependent = package.back();
+    std::unordered_set<uint256, SaltedTxidHasher> dependency_txids;
+    for (auto it = package.rbegin(); it != package.rend(); ++it) {
+        const auto& tx = *it;
+        // Each transaction must be a dependency of the last transaction.
+        if (tx->GetWitnessHash() != dependent->GetWitnessHash() &&
+            dependency_txids.count(tx->GetHash()) == 0) {
+            return false;
+        }
+        // Add each transaction's dependencies to allow transactions which are ancestors but not
+        // necessarily direct parents of the last transaction.
+        std::transform(tx->vin.cbegin(), tx->vin.cend(),
+                       std::inserter(dependency_txids, dependency_txids.end()),
+                       [](const auto& input) { return input.prevout.hash; });
+    }
+    return true;
+}
+
 BOOST_FIXTURE_TEST_CASE(package_sanitization_tests, TestChain100Setup)
 {
     // Packages can't have more than 25 transactions.
@@ -63,6 +87,117 @@ BOOST_FIXTURE_TEST_CASE(package_sanitization_tests, TestChain100Setup)
     BOOST_CHECK(!IsPackageWellFormed(package_too_large, state_too_large));
     BOOST_CHECK_EQUAL(state_too_large.GetResult(), PackageValidationResult::PCKG_POLICY);
     BOOST_CHECK_EQUAL(state_too_large.GetRejectReason(), "package-too-large");
+}
+BOOST_FIXTURE_TEST_CASE(packageifier_tests, TestChain100Setup)
+{
+    CKey placeholder_key;
+    placeholder_key.MakeNewKey(true);
+    CScript spk = GetScriptForDestination(PKHash(placeholder_key.GetPubKey()));
+    FastRandomContext det_rand{true};
+    // Basic chain of 25 transactions
+    {
+        Package package;
+        CTransactionRef last_tx = m_coinbase_txns[0];
+        CKey signing_key = coinbaseKey;
+        for (int i{0}; i < 24; ++i) {
+            auto tx = MakeTransactionRef(CreateValidMempoolTransaction(last_tx, 0, 0, signing_key, spk, CAmount((49-i) * COIN), false));
+            package.emplace_back(tx);
+            last_tx = tx;
+            if (i == 0) signing_key = placeholder_key;
+        }
+        BOOST_CHECK(!IsChildWithParents(package));
+        BOOST_CHECK(IsAncestorPackage(package));
+
+        Package package_copy = package;
+        Shuffle(package_copy.begin(), package_copy.end(), det_rand);
+        Packageifier packageified(package_copy);
+        BOOST_CHECK(IsAncestorPackage(packageified.Txns()));
+        for (auto i{0}; i < 24; ++i) {
+            BOOST_CHECK_EQUAL(packageified.GetAncestorSet(package[i])->size(), i + 1);
+            BOOST_CHECK(IsAncestorPackage(*packageified.GetAncestorSet(package[i])));
+        }
+        for (auto i{0}; i < 10; ++i) packageified.Exclude(package[i]);
+        packageified.Ban(package[20]);
+        for (auto i{11}; i < 20; ++i) {
+            const auto& tx = package[i];
+            BOOST_CHECK_EQUAL(packageified.GetAncestorSet(tx)->size(), i - 9);
+            BOOST_CHECK(IsAncestorPackage(*packageified.GetAncestorSet(tx)));
+        }
+        for (auto i{20}; i < 24; ++i) {
+            BOOST_CHECK(!packageified.GetAncestorSet(package[i]));
+        }
+    }
+    // 99 Parents and 1 Child
+    {
+        Package package;
+        CMutableTransaction child;
+        for (int i{0}; i < 99; ++i) {
+            auto parent = MakeTransactionRef(CreateValidMempoolTransaction(m_coinbase_txns[i + 1],
+                                             0, 0, coinbaseKey, spk, CAmount(49 * COIN), false));
+            package.emplace_back(parent);
+            child.vin.push_back(CTxIn(COutPoint(parent->GetHash(), 0)));
+        }
+        child.vout.push_back(CTxOut(4900 * COIN, spk));
+        package.push_back(MakeTransactionRef(child));
+
+        Package package_copy(package);
+        Shuffle(package_copy.begin(), package_copy.end(), det_rand);
+        Packageifier packageified(package_copy);
+        for (auto i{0}; i < 99; ++i) {
+            BOOST_CHECK_EQUAL(packageified.GetAncestorSet(package[i])->size(), 1);
+            BOOST_CHECK(IsAncestorPackage(*packageified.GetAncestorSet(packageified.Txns()[i])));
+            if (i < 50) packageified.Exclude(package[i]);
+        }
+        BOOST_CHECK_EQUAL(packageified.GetAncestorSet(package.back())->size(), 50);
+        BOOST_CHECK(IsAncestorPackage(*packageified.GetAncestorSet(package.back())));
+        packageified.Ban(package[75]);
+        for (auto i{50}; i < 99; ++i) {
+            if (i == 75) {
+                BOOST_CHECK(!packageified.GetAncestorSet(package[i]));
+            } else {
+                BOOST_CHECK_EQUAL(packageified.GetAncestorSet(package[i])->size(), 1);
+            }
+        }
+        BOOST_CHECK(!packageified.GetAncestorSet(package.back()));
+    }
+
+    // Heavily inter-connected set of 500 transactions
+    LOCK2(cs_main, m_node.mempool->cs);
+    auto transactions{PopulateMempool(det_rand, /*num_transactions=*/500, /*submit=*/true)};
+    Shuffle(transactions.begin(), transactions.end(), det_rand);
+    Packageifier packageified{transactions};
+    const auto sorted_transactions{packageified.Txns()};
+    BOOST_CHECK(IsSorted(sorted_transactions));
+    for (const auto& tx : sorted_transactions) {
+        const auto packageified_ancestors{packageified.GetAncestorSet(tx)};
+        BOOST_CHECK(IsAncestorPackage(*packageified_ancestors));
+        auto mempool_ancestors{m_node.mempool->CalculateMemPoolAncestors(*m_node.mempool->GetIter(tx->GetHash()).value(),
+                               CTxMemPool::Limits::NoLimits(), /*fSearchForParents=*/false)};
+        // Add 1 because CMPA doesn't include the tx itself in its ancestor set.
+        BOOST_CHECK_EQUAL(mempool_ancestors->size() + 1, packageified_ancestors->size());
+        std::set<uint256> packageified_ancestors_wtxids;
+        for (const auto& tx : packageified_ancestors.value()) packageified_ancestors_wtxids.insert(tx->GetWitnessHash());
+        for (const auto& mempool_iter : *mempool_ancestors) {
+            BOOST_CHECK(packageified_ancestors_wtxids.count(mempool_iter->GetTx().GetWitnessHash()) > 0);
+        }
+    }
+    // Exclude the 200th transaction. All of its descendants should have 1 fewer tx in their ancestor sets.
+    const auto& tx_200{sorted_transactions[200]};
+    CTxMemPool::setEntries descendants_200;
+    m_node.mempool->CalculateDescendants(m_node.mempool->GetIter(tx_200->GetHash()).value(), descendants_200);
+    packageified.Exclude(tx_200);
+    for (const auto& desc_iter : descendants_200) {
+        BOOST_CHECK_EQUAL(packageified.GetAncestorSet(m_node.mempool->info(GenTxid::Txid(desc_iter->GetTx().GetHash())).tx)->size(),
+                          desc_iter->GetCountWithAncestors() - 1);
+    }
+    // Ban the 400th transaction. GetAncestorSet() for all of its descendants should return std::nullopt.
+    const auto& tx_400{sorted_transactions[400]};
+    CTxMemPool::setEntries descendants_400;
+    m_node.mempool->CalculateDescendants(m_node.mempool->GetIter(tx_400->GetHash()).value(), descendants_400);
+    packageified.Ban(tx_400);
+    for (const auto& desc_iter : descendants_400) {
+        BOOST_CHECK(!packageified.GetAncestorSet(m_node.mempool->info(GenTxid::Txid(desc_iter->GetTx().GetHash())).tx));
+    }
 }
 
 BOOST_FIXTURE_TEST_CASE(package_validation_tests, TestChain100Setup)
@@ -208,6 +343,7 @@ BOOST_FIXTURE_TEST_CASE(noncontextual_package_tests, TestChain100Setup)
         BOOST_CHECK(IsChildWithParents({tx_parent, tx_parent_also_child, tx_child}));
         // IsChildWithParents does not detect unsorted parents.
         BOOST_CHECK(IsChildWithParents({tx_parent_also_child, tx_parent, tx_child}));
+        BOOST_CHECK(!IsSorted({tx_parent_also_child, tx_parent, tx_child}));
         BOOST_CHECK(IsPackageWellFormed({tx_parent, tx_parent_also_child, tx_child}, state));
         BOOST_CHECK(!IsPackageWellFormed({tx_parent_also_child, tx_parent, tx_child}, state));
         BOOST_CHECK_EQUAL(state.GetResult(), PackageValidationResult::PCKG_POLICY);

--- a/src/test/txpackagetracker_tests.cpp
+++ b/src/test/txpackagetracker_tests.cpp
@@ -3,16 +3,36 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <node/txpackagetracker.h>
+#include <random.h>
 #include <txorphanage.h>
 
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
 
+static inline CTransactionRef make_tx(const std::vector<COutPoint>& inputs, size_t num_outputs)
+{
+    CMutableTransaction tx = CMutableTransaction();
+    tx.vin.resize(inputs.size());
+    tx.vout.resize(num_outputs);
+    for (size_t i = 0; i < inputs.size(); ++i) {
+        tx.vin[i].prevout = inputs[i];
+        // Add a witness so wtxid != txid
+        CScriptWitness witness;
+        witness.stack.push_back(std::vector<unsigned char>(i + 10));
+        tx.vin[i].scriptWitness = witness;
+    }
+    for (size_t i = 0; i < num_outputs; ++i) {
+        tx.vout[i].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+        tx.vout[i].nValue = COIN;
+    }
+    return MakeTransactionRef(tx);
+}
+
 BOOST_FIXTURE_TEST_SUITE(txpackagetracker_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(pkginfo)
 {
-    TxOrphanage orphanage;
+    FastRandomContext det_rand{true};
     node::TxPackageTracker tracker;
     BOOST_CHECK_EQUAL(tracker.GetVersions().size(), 1);
 
@@ -45,6 +65,58 @@ BOOST_AUTO_TEST_CASE(pkginfo)
         BOOST_CHECK_EQUAL(tracker.Count(i), 0);
         BOOST_CHECK_EQUAL(tracker.CountInFlight(i), 0);
     }
+
+    const auto current_time{GetTime<std::chrono::microseconds>()};
+    const auto orphan0 = make_tx({COutPoint{det_rand.rand256(), 0}}, 1);
+    const auto wtxid_parent1 = det_rand.rand256();
+    const auto orphan1 = make_tx({COutPoint{wtxid_parent1, 0}, COutPoint{wtxid_parent1, 1}}, 1);
+    const auto orphan2 = make_tx({COutPoint{det_rand.rand256(), 0}, COutPoint{det_rand.rand256(), 0}}, 1);
+    tracker.AddOrphanTx(/*nodeid=*/0, orphan0->GetWitnessHash(), orphan0, /*is_preferred=*/false, current_time);
+    tracker.AddOrphanTx(/*nodeid=*/1, orphan1->GetWitnessHash(), orphan1, /*is_preferred=*/false, current_time);
+    tracker.AddOrphanTx(/*nodeid=*/1, orphan0->GetWitnessHash(), orphan0, /*is_preferred=*/false, current_time + 10s);
+    tracker.AddOrphanTx(/*nodeid=*/2, orphan1->GetWitnessHash(), orphan1, /*is_preferred=*/false, current_time + 5s);
+    tracker.AddOrphanTx(/*nodeid=*/3, orphan2->GetWitnessHash(), orphan2, /*is_preferred=*/true, current_time + 5s);
+    tracker.AddOrphanTx(/*nodeid=*/4, orphan2->GetWitnessHash(), orphan2, /*is_preferred=*/false, current_time + 9s);
+    BOOST_CHECK_EQUAL(tracker.Count(0), 1);
+    BOOST_CHECK_EQUAL(tracker.Count(1), 2);
+    BOOST_CHECK_EQUAL(tracker.Count(2), 1);
+    BOOST_CHECK_EQUAL(tracker.Count(3), 1);
+    BOOST_CHECK_EQUAL(tracker.Count(4), 1);
+    const auto peer0_requests = tracker.GetOrphanRequests(/*nodeid=*/0, current_time + 1s);
+    const auto peer1_requests = tracker.GetOrphanRequests(/*nodeid=*/1, current_time + 1s);
+    const auto peer2_requests = tracker.GetOrphanRequests(/*nodeid=*/2, current_time + 1s);
+    const auto peer3_requests = tracker.GetOrphanRequests(/*nodeid=*/3, current_time);
+    const auto peer4_requests = tracker.GetOrphanRequests(/*nodeid=*/4, current_time);
+    BOOST_CHECK_EQUAL(peer0_requests.size(), 1);
+    BOOST_CHECK(peer0_requests.front().IsWtxid());
+    BOOST_CHECK_EQUAL(peer0_requests.front().GetHash(), orphan0->GetWitnessHash());
+    BOOST_CHECK_EQUAL(peer1_requests.size(), 1);
+    BOOST_CHECK_EQUAL(peer1_requests.front().GetHash(), wtxid_parent1);
+    BOOST_CHECK(!peer1_requests.front().IsWtxid());
+    BOOST_CHECK(peer2_requests.empty());
+    BOOST_CHECK(peer3_requests.empty());
+    BOOST_CHECK(peer4_requests.empty());
+    BOOST_CHECK_EQUAL(tracker.CountInFlight(0), 1);
+    BOOST_CHECK_EQUAL(tracker.CountInFlight(1), 1);
+    BOOST_CHECK_EQUAL(tracker.Count(1), 2);
+    BOOST_CHECK_EQUAL(tracker.CountInFlight(2), 0);
+    BOOST_CHECK_EQUAL(tracker.CountInFlight(3), 0);
+    BOOST_CHECK_EQUAL(tracker.CountInFlight(4), 0);
+    // After peer1 disconnects, request from peer2
+    tracker.DisconnectedPeer(/*nodeid=*/1);
+    // After peer3 disconnects, request from peer4
+    tracker.DisconnectedPeer(/*nodeid=*/3);
+    BOOST_CHECK_EQUAL(tracker.Count(3), 0);
+    BOOST_CHECK_EQUAL(tracker.CountInFlight(3), 0);
+    const auto peer2_requests_later = tracker.GetOrphanRequests(/*nodeid=*/2, current_time + 5s);
+    // 2 inputs but only 1 unique parent
+    BOOST_CHECK_EQUAL(peer2_requests_later.size(), 1);
+    BOOST_CHECK(!peer2_requests_later.front().IsWtxid());
+    BOOST_CHECK_EQUAL(peer2_requests_later.front().GetHash(), wtxid_parent1);
+    const auto peer4_requests_later = tracker.GetOrphanRequests(/*nodeid=*/4, current_time + 9s);
+    BOOST_CHECK_EQUAL(peer4_requests_later.size(), 2);
+    // This counts as 1 in-flight request
+    BOOST_CHECK_EQUAL(tracker.CountInFlight(4), 1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txpackagetracker_tests.cpp
+++ b/src/test/txpackagetracker_tests.cpp
@@ -117,6 +117,74 @@ BOOST_AUTO_TEST_CASE(pkginfo)
     BOOST_CHECK_EQUAL(peer4_requests_later.size(), 2);
     // This counts as 1 in-flight request
     BOOST_CHECK_EQUAL(tracker.CountInFlight(4), 1);
+
+    // peer0 is allowed to send ancpkginfo for orphan0, but not for any other tx or version
+    BOOST_CHECK(tracker.PkgInfoAllowed(/*nodeid=*/0, orphan0->GetWitnessHash(), node::RECEIVER_INIT_ANCESTOR_PACKAGES));
+    BOOST_CHECK(!tracker.PkgInfoAllowed(/*nodeid=*/0, orphan0->GetWitnessHash(), unsupported_package_type));
+    BOOST_CHECK(!tracker.PkgInfoAllowed(/*nodeid=*/0, orphan1->GetWitnessHash(), node::RECEIVER_INIT_ANCESTOR_PACKAGES));
+    // No other peers are allowed to send ancpkginfo (they disconnected or aren't registered for it)
+    BOOST_CHECK(!tracker.PkgInfoAllowed(/*nodeid=*/1, orphan1->GetWitnessHash(), node::RECEIVER_INIT_ANCESTOR_PACKAGES));
+    BOOST_CHECK(!tracker.PkgInfoAllowed(/*nodeid=*/2, orphan1->GetWitnessHash(), node::RECEIVER_INIT_ANCESTOR_PACKAGES));
+    BOOST_CHECK(!tracker.PkgInfoAllowed(/*nodeid=*/3, orphan2->GetWitnessHash(), node::RECEIVER_INIT_ANCESTOR_PACKAGES));
+    BOOST_CHECK(!tracker.PkgInfoAllowed(/*nodeid=*/4, orphan2->GetWitnessHash(), node::RECEIVER_INIT_ANCESTOR_PACKAGES));
+
+    // After receiving ancpkginfo, a second ancpkginfo is not allowed
+    const auto missing_wtxid{det_rand.rand256()};
+    std::map<uint256, bool> txdata_status_map;
+    txdata_status_map.emplace(missing_wtxid, true);
+    txdata_status_map.emplace(orphan0->GetWitnessHash(), false);
+    std::vector<uint256> missing_wtxids{missing_wtxid};
+    BOOST_CHECK(!tracker.ReceivedAncPkgInfo(/*nodeid=*/0, orphan0->GetWitnessHash(), txdata_status_map,
+                                            missing_wtxids, current_time + 100s));
+    BOOST_CHECK(!tracker.PkgInfoAllowed(/*nodeid=*/0, orphan0->GetWitnessHash(), node::RECEIVER_INIT_ANCESTOR_PACKAGES));
+}
+void RegisterPeerForAncestorPackages(node::TxPackageTracker& tracker, NodeId peer)
+{
+    tracker.ReceivedVersion(peer);
+    tracker.ReceivedSendpackages(peer, node::RECEIVER_INIT_ANCESTOR_PACKAGES);
+    tracker.ReceivedVerack(peer, true, true);
+}
+BOOST_AUTO_TEST_CASE(txdata_download)
+{
+    FastRandomContext det_rand{true};
+    node::TxPackageTracker tracker;
+
+    // 2 parents 1 child
+    const auto tx_parent1 = make_tx({COutPoint{det_rand.rand256(), 0}}, 1);
+    const auto tx_parent2 = make_tx({COutPoint{det_rand.rand256(), 0}}, 1);
+    const auto tx_child = make_tx({COutPoint{tx_parent1->GetHash(), 0}, COutPoint{tx_parent2->GetHash(), 0}}, 1);
+    const Package package_2p1c{tx_parent1, tx_parent2, tx_child};
+
+    const auto current_time{GetTime<std::chrono::microseconds>()};
+    {
+    NodeId peer = 0;
+    RegisterPeerForAncestorPackages(tracker, peer);
+
+    tracker.AddOrphanTx(peer, tx_child->GetWitnessHash(), tx_child, /*is_preferred=*/true, current_time);
+    const auto requests = tracker.GetOrphanRequests(peer, current_time + 1s);
+    BOOST_CHECK_EQUAL(1, requests.size());
+    BOOST_CHECK(tracker.PkgInfoAllowed(peer, tx_child->GetWitnessHash(), node::RECEIVER_INIT_ANCESTOR_PACKAGES));
+
+    const std::vector<uint256> missing_wtxids{tx_parent1->GetWitnessHash(), tx_parent2->GetWitnessHash()};
+    std::map<uint256, bool> txdata_status_map;
+    txdata_status_map.emplace(tx_parent1->GetWitnessHash(), true);
+    txdata_status_map.emplace(tx_parent2->GetWitnessHash(), true);
+    txdata_status_map.emplace(tx_child->GetWitnessHash(), false);
+    BOOST_CHECK(!tracker.ReceivedAncPkgInfo(peer, tx_child->GetWitnessHash(), txdata_status_map,
+                                            missing_wtxids, current_time + 100s));
+
+    // Nodeid and exact missing transactions must match.
+    BOOST_CHECK(!tracker.ReceivedPkgTxns(peer, {tx_parent1}).has_value());
+    BOOST_CHECK(!tracker.ReceivedPkgTxns(peer, {tx_parent2}).has_value());
+    BOOST_CHECK(!tracker.ReceivedPkgTxns(2, {tx_parent1, tx_parent2}).has_value());
+
+    const auto validate_2p1c = tracker.ReceivedPkgTxns(peer, {tx_parent1, tx_parent2});
+    BOOST_CHECK(validate_2p1c.has_value());
+    BOOST_CHECK_EQUAL(validate_2p1c.value().m_info_provider, peer);
+    BOOST_CHECK_EQUAL(validate_2p1c->m_rep_wtxid, tx_child->GetWitnessHash());
+    BOOST_CHECK_EQUAL(validate_2p1c->m_pkginfo_hash, GetPackageHash(package_2p1c));
+    BOOST_CHECK(validate_2p1c->m_unvalidated_txns == package_2p1c);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txpackagetracker_tests.cpp
+++ b/src/test/txpackagetracker_tests.cpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2021-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/txpackagetracker.h>
+#include <txorphanage.h>
+
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(txpackagetracker_tests, BasicTestingSetup)
+BOOST_AUTO_TEST_CASE(pkginfo)
+{
+    TxOrphanage orphanage;
+    node::TxPackageTracker tracker;
+    BOOST_CHECK_EQUAL(tracker.GetVersions().size(), 1);
+
+    // Peer 0: successful handshake
+    NodeId peer = 0;
+    tracker.ReceivedVersion(peer);
+    tracker.ReceivedSendpackages(peer, node::RECEIVER_INIT_ANCESTOR_PACKAGES);
+    BOOST_CHECK(tracker.ReceivedVerack(peer, /*txrelay=*/true, /*wtxidrelay=*/true));
+
+    // Peer 1: unsupported version(s)
+    const uint32_t unsupported_package_type{3};
+    peer = 1;
+    tracker.ReceivedVersion(peer);
+    tracker.ReceivedSendpackages(peer, unsupported_package_type);
+    BOOST_CHECK(tracker.ReceivedVerack(peer, /*txrelay=*/true, /*wtxidrelay=*/true));
+
+    // Peer 2: no wtxidrelay
+    peer = 2;
+    tracker.ReceivedVersion(peer);
+    tracker.ReceivedSendpackages(peer, node::RECEIVER_INIT_ANCESTOR_PACKAGES);
+    BOOST_CHECK(!tracker.ReceivedVerack(peer, /*txrelay=*/true, /*wtxidrelay=*/false));
+
+    // Peer 3: fRelay=false
+    peer = 3;
+    tracker.ReceivedVersion(peer);
+    tracker.ReceivedSendpackages(peer, node::RECEIVER_INIT_ANCESTOR_PACKAGES);
+    BOOST_CHECK(!tracker.ReceivedVerack(peer, /*txrelay=*/false, /*wtxidrelay=*/true));
+
+    for (NodeId i{0}; i < peer + 1; ++i) {
+        BOOST_CHECK_EQUAL(tracker.Count(i), 0);
+        BOOST_CHECK_EQUAL(tracker.CountInFlight(i), 0);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -432,6 +432,32 @@ std::vector<CTransactionRef> TestChain100Setup::PopulateMempool(FastRandomContex
     return mempool_transactions;
 }
 
+void TestChain100Setup::MockMempoolMinFee(const CFeeRate& target_feerate)
+{
+    LOCK2(cs_main, m_node.mempool->cs);
+    // Transactions in the mempool will affect the new minimum feerate.
+    assert(m_node.mempool->size() == 0);
+    // The target feerate cannot be too low...
+    // ...otherwise the transaction's feerate will need to be negative.
+    assert(target_feerate > m_node.mempool->m_incremental_relay_feerate);
+    // ...otherwise this is not meaningful. The feerate policy uses the maximum of both feerates.
+    assert(target_feerate > m_node.mempool->m_min_relay_feerate);
+
+    // Manually create an invalid transaction. Manually set the fee in the CTxMemPoolEntry to
+    // achieve the exact target feerate.
+    CMutableTransaction mtx = CMutableTransaction();
+    mtx.vin.push_back(CTxIn{COutPoint{g_insecure_rand_ctx.rand256(), 0}});
+    mtx.vout.push_back(CTxOut(1 * COIN, GetScriptForDestination(WitnessV0ScriptHash(CScript() << OP_TRUE))));
+    const auto tx{MakeTransactionRef(mtx)};
+    LockPoints lp;
+    const auto tx_fee = target_feerate.GetFee(GetVirtualTransactionSize(*tx)) -
+        m_node.mempool->m_incremental_relay_feerate.GetFee(GetVirtualTransactionSize(*tx));
+    m_node.mempool->addUnchecked(CTxMemPoolEntry(tx, /*fee=*/tx_fee,
+                                                 /*time=*/0, /*entry_height=*/1,
+                                                 /*spends_coinbase=*/true, /*sigops_cost=*/1, lp));
+    m_node.mempool->TrimToSize(0);
+    assert(m_node.mempool->GetMinFee() == target_feerate);
+}
 /**
  * @returns a real block (0000000000013b8ab2cd513b0261a14096412195a72a0c4827d229dcc7e0f7af)
  *      with 9 txs.

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -258,7 +258,7 @@ TestingSetup::TestingSetup(
     m_node.connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman); // Deterministic randomness for tests.
     m_node.peerman = PeerManager::make(*m_node.connman, *m_node.addrman,
                                        m_node.banman.get(), *m_node.chainman,
-                                       *m_node.mempool, false);
+                                       *m_node.mempool, false, false);
     {
         CConnman::Options options;
         options.m_msgproc = m_node.peerman.get();

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -335,40 +335,41 @@ CBlock TestChain100Setup::CreateAndProcessBlock(
 }
 
 
-CMutableTransaction TestChain100Setup::CreateValidMempoolTransaction(CTransactionRef input_transaction,
-                                                                     int input_vout,
+CMutableTransaction TestChain100Setup::CreateValidMempoolTransaction(const std::vector<CTransactionRef>& input_transactions,
+                                                                     const std::vector<COutPoint>& inputs,
                                                                      int input_height,
-                                                                     CKey input_signing_key,
-                                                                     CScript output_destination,
-                                                                     CAmount output_amount,
+                                                                     const std::vector<CKey>& input_signing_keys,
+                                                                     const std::vector<CTxOut>& outputs,
                                                                      bool submit)
 {
-    // Transaction we will submit to the mempool
     CMutableTransaction mempool_txn;
+    mempool_txn.vin.reserve(inputs.size());
+    mempool_txn.vout.reserve(outputs.size());
 
-    // Create an input
-    COutPoint outpoint_to_spend(input_transaction->GetHash(), input_vout);
-    CTxIn input(outpoint_to_spend);
-    mempool_txn.vin.push_back(input);
+    for (const auto& outpoint : inputs) {
+        mempool_txn.vin.emplace_back(CTxIn{outpoint});
+    }
+    mempool_txn.vout = outputs;
 
-    // Create an output
-    CTxOut output(output_amount, output_destination);
-    mempool_txn.vout.push_back(output);
-
-    // Sign the transaction
     // - Add the signing key to a keystore
     FillableSigningProvider keystore;
-    keystore.AddKey(input_signing_key);
+    for (const auto& input_signing_key : input_signing_keys) {
+        keystore.AddKey(input_signing_key);
+    }
     // - Populate a CoinsViewCache with the unspent output
     CCoinsView coins_view;
     CCoinsViewCache coins_cache(&coins_view);
-    AddCoins(coins_cache, *input_transaction.get(), input_height);
-    // - Use GetCoin to properly populate utxo_to_spend,
-    Coin utxo_to_spend;
-    assert(coins_cache.GetCoin(outpoint_to_spend, utxo_to_spend));
-    // - Then add it to a map to pass in to SignTransaction
+    for (const auto& input_transaction : input_transactions) {
+        AddCoins(coins_cache, *input_transaction.get(), input_height);
+    }
+    // Build Outpoint to Coin map for SignTransaction
     std::map<COutPoint, Coin> input_coins;
-    input_coins.insert({outpoint_to_spend, utxo_to_spend});
+    for (const auto& outpoint_to_spend : inputs) {
+        // - Use GetCoin to properly populate utxo_to_spend,
+        Coin utxo_to_spend;
+        assert(coins_cache.GetCoin(outpoint_to_spend, utxo_to_spend));
+        input_coins.insert({outpoint_to_spend, utxo_to_spend});
+    }
     // - Default signature hashing type
     int nHashType = SIGHASH_ALL;
     std::map<int, bilingual_str> input_errors;
@@ -382,6 +383,24 @@ CMutableTransaction TestChain100Setup::CreateValidMempoolTransaction(CTransactio
     }
 
     return mempool_txn;
+}
+
+CMutableTransaction TestChain100Setup::CreateValidMempoolTransaction(CTransactionRef input_transaction,
+                                                                     uint32_t input_vout,
+                                                                     int input_height,
+                                                                     CKey input_signing_key,
+                                                                     CScript output_destination,
+                                                                     CAmount output_amount,
+                                                                     bool submit)
+{
+    COutPoint input{input_transaction->GetHash(), input_vout};
+    CTxOut output{output_amount, output_destination};
+    return CreateValidMempoolTransaction(/*input_transactions=*/{input_transaction},
+                                         /*inputs=*/{input},
+                                         /*input_height=*/input_height,
+                                         /*input_signing_keys=*/{input_signing_key},
+                                         /*outputs=*/{output},
+                                         /*submit=*/submit);
 }
 
 std::vector<CTransactionRef> TestChain100Setup::PopulateMempool(FastRandomContext& det_rand, size_t num_transactions, bool submit)

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -23,6 +23,7 @@
 #include <type_traits>
 #include <vector>
 
+class CFeeRate;
 class Chainstate;
 
 /** This is connected to the logger. Can be used to redirect logs to any other log */
@@ -184,6 +185,17 @@ struct TestChain100Setup : public TestingSetup {
      * @returns A vector of transactions that can be submitted to the mempool.
      */
     std::vector<CTransactionRef> PopulateMempool(FastRandomContext& det_rand, size_t num_transactions, bool submit);
+
+    /** Mock the mempool minimum feerate by adding a transaction and calling TrimToSize(0),
+     * simulating the mempool "reaching capacity" and evicting by descendant feerate.  Note that
+     * this clears the mempool, and the new minimum feerate will depend on the maximum feerate of
+     * transactions removed, so this must be called while the mempool is empty.
+     *
+     * @param target_feerate    The new mempool minimum feerate after this function returns.
+     *                          Must be above max(incremental feerate, min relay feerate),
+     *                          or 1sat/vB with default settings.
+     */
+    void MockMempoolMinFee(const CFeeRate& target_feerate);
 
     std::vector<CTransactionRef> m_coinbase_txns; // For convenience, coinbase transactions
     CKey coinbaseKey; // private/public key needed to spend coinbase transactions

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -157,6 +157,23 @@ struct TestChain100Setup : public TestingSetup {
     /**
      * Create a transaction and submit to the mempool.
      *
+     * @param input_transactions   The transactions to spend
+     * @param input_height         The height of the block that included the input transactions.
+     * @param inputs               Outpoints with which to construct transaction vin.
+     * @param input_signing_keys   The keys to spend the input transactions.
+     * @param outputs              Transaction vout.
+     * @param submit               Whether or not to submit to mempool
+     */
+    CMutableTransaction CreateValidMempoolTransaction(const std::vector<CTransactionRef>& input_transactions,
+                                                      const std::vector<COutPoint>& inputs,
+                                                      int input_height,
+                                                      const std::vector<CKey>& input_signing_keys,
+                                                      const std::vector<CTxOut>& outputs,
+                                                      bool submit = true);
+
+    /**
+     * Create a transaction and submit to the mempool.
+     *
      * @param input_transaction  The transaction to spend
      * @param input_vout         The vout to spend from the input_transaction
      * @param input_height       The height of the block that included the input_transaction
@@ -166,7 +183,7 @@ struct TestChain100Setup : public TestingSetup {
      * @param submit             Whether or not to submit to mempool
      */
     CMutableTransaction CreateValidMempoolTransaction(CTransactionRef input_transaction,
-                                                      int input_vout,
+                                                      uint32_t input_vout,
                                                       int input_height,
                                                       CKey input_signing_key,
                                                       CScript output_destination,

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1057,17 +1057,23 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpends
 
     unsigned nTxnRemoved = 0;
     CFeeRate maxFeeRateRemoved(0);
-    while (!mapTx.empty() && DynamicMemoryUsage() > sizelimit) {
+    while (!mapTx.empty()) {
         indexed_transaction_set::index<descendant_score>::type::iterator it = mapTx.get<descendant_score>().begin();
+
+        CFeeRate removed(it->GetModFeesWithDescendants(), it->GetSizeWithDescendants());
+        // Skim away everything paying effectively zero fees, regardless of mempool size.
+        // Above that feerate, just trim until memory is within limits.
+        if (removed >= m_min_relay_feerate && DynamicMemoryUsage() <= sizelimit) break;
 
         // We set the new mempool min fee to the feerate of the removed set, plus the
         // "minimum reasonable fee rate" (ie some value under which we consider txn
         // to have 0 fee). This way, we don't allow txn to enter mempool with feerate
         // equal to txn which were removed with no block in between.
-        CFeeRate removed(it->GetModFeesWithDescendants(), it->GetSizeWithDescendants());
-        removed += m_incremental_relay_feerate;
-        trackPackageRemoved(removed);
-        maxFeeRateRemoved = std::max(maxFeeRateRemoved, removed);
+        if (removed >= m_min_relay_feerate) {
+            removed += m_incremental_relay_feerate;
+            trackPackageRemoved(removed);
+            maxFeeRateRemoved = std::max(maxFeeRateRemoved, removed);
+        }
 
         setEntries stage;
         CalculateDescendants(mapTx.project<0>(it), stage);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -846,6 +846,20 @@ TxMempoolInfo CTxMemPool::info(const GenTxid& gtxid) const
     return GetInfo(i);
 }
 
+std::optional<CFeeRate> CTxMemPool::MinimumFeerateWithParents(const GenTxid& gtxid) const
+{
+    LOCK(cs);
+    indexed_transaction_set::const_iterator i = (gtxid.IsWtxid() ? get_iter_from_wtxid(gtxid.GetHash()) : mapTx.find(gtxid.GetHash()));
+    if (i == mapTx.end()) return std::nullopt;
+    CFeeRate min_feerate(i->GetFee(), i->GetTxSize());
+    for (const auto& parent : i->GetMemPoolParentsConst()) {
+        auto pit = mapTx.iterator_to(parent);
+        CFeeRate parent_feerate(pit->GetFee(), pit->GetTxSize());
+        if (parent_feerate < min_feerate) min_feerate = parent_feerate;
+    }
+    return min_feerate;
+}
+
 void CTxMemPool::PrioritiseTransaction(const uint256& hash, const CAmount& nFeeDelta)
 {
     {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -681,6 +681,11 @@ public:
     TxMempoolInfo info(const GenTxid& gtxid) const;
     std::vector<TxMempoolInfo> infoAll() const;
 
+    /** Get the minimum base feerate between this entry and its parents (ignoring prioritisation).
+     * returns std::nullopt if the entry doesn't exist
+     * returns the tx's own feerate if it doesn't have any parents */
+    std::optional<CFeeRate> MinimumFeerateWithParents(const GenTxid& gtxid) const;
+
     size_t DynamicMemoryUsage() const;
 
     /** Adds a transaction to the unbroadcast set */

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -52,6 +52,13 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
     return true;
 }
 
+CTransactionRef TxOrphanage::GetTx(const uint256& wtxid)
+{
+   LOCK(m_mutex);
+   const auto it = m_wtxid_to_orphan_it.find(wtxid);
+   return it == m_wtxid_to_orphan_it.end() ? nullptr : it->second->second.tx;
+}
+
 int TxOrphanage::EraseTx(const uint256& txid)
 {
     LOCK(m_mutex);

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -213,7 +213,7 @@ bool TxOrphanage::HaveTxToReconsider(NodeId peer)
     return false;
 }
 
-void TxOrphanage::EraseForBlock(const CBlock& block)
+std::vector<uint256> TxOrphanage::EraseForBlock(const CBlock& block)
 {
     LOCK(m_mutex);
 
@@ -242,4 +242,5 @@ void TxOrphanage::EraseForBlock(const CBlock& block)
         }
         LogPrint(BCLog::MEMPOOL, "Erased %d orphan tx included or conflicted by block\n", nErased);
     }
+    return vOrphanErase;
 }

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -18,6 +18,7 @@ static constexpr int64_t ORPHAN_TX_EXPIRE_INTERVAL = 5 * 60;
 bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
 {
     LOCK(m_mutex);
+    if (tx == nullptr) return false;
 
     const uint256& hash = tx->GetHash();
     if (m_orphans.count(hash))

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -59,18 +59,18 @@ CTransactionRef TxOrphanage::GetTx(const uint256& wtxid)
    return it == m_wtxid_to_orphan_it.end() ? nullptr : it->second->second.tx;
 }
 
-int TxOrphanage::EraseTx(const uint256& txid)
+int TxOrphanage::EraseTx(const uint256& wtxid)
 {
     LOCK(m_mutex);
-    return _EraseTx(txid);
+    return _EraseTx(wtxid);
 }
 
-int TxOrphanage::_EraseTx(const uint256& txid)
+int TxOrphanage::_EraseTx(const uint256& wtxid)
 {
     AssertLockHeld(m_mutex);
-    std::map<uint256, OrphanTx>::iterator it = m_orphans.find(txid);
-    if (it == m_orphans.end())
-        return 0;
+    const auto wtxid_it = m_wtxid_to_orphan_it.find(wtxid);
+    if (wtxid_it == m_wtxid_to_orphan_it.end()) return 0;
+    std::map<uint256, OrphanTx>::iterator it = wtxid_it->second;
     for (const CTxIn& txin : it->second.tx->vin)
     {
         auto itPrev = m_outpoint_to_orphan_it.find(txin.prevout);
@@ -110,7 +110,7 @@ void TxOrphanage::EraseForPeer(NodeId peer)
         std::map<uint256, OrphanTx>::iterator maybeErase = iter++; // increment to avoid iterator becoming invalid
         if (maybeErase->second.fromPeer == peer)
         {
-            nErased += _EraseTx(maybeErase->second.tx->GetHash());
+            nErased += _EraseTx(maybeErase->second.tx->GetWitnessHash());
         }
     }
     if (nErased > 0) LogPrint(BCLog::MEMPOOL, "Erased %d orphan tx from peer=%d\n", nErased, peer);
@@ -132,7 +132,7 @@ void TxOrphanage::LimitOrphans(unsigned int max_orphans)
         {
             std::map<uint256, OrphanTx>::iterator maybeErase = iter++;
             if (maybeErase->second.nTimeExpire <= nNow) {
-                nErased += _EraseTx(maybeErase->second.tx->GetHash());
+                nErased += _EraseTx(maybeErase->second.tx->GetWitnessHash());
             } else {
                 nMinExpTime = std::min(maybeErase->second.nTimeExpire, nMinExpTime);
             }
@@ -146,7 +146,7 @@ void TxOrphanage::LimitOrphans(unsigned int max_orphans)
     {
         // Evict a random orphan:
         size_t randompos = rng.randrange(m_orphan_list.size());
-        _EraseTx(m_orphan_list[randompos]->first);
+        _EraseTx(m_orphan_list[randompos]->second.tx->GetWitnessHash());
         ++nEvicted;
     }
     if (nEvicted > 0) LogPrint(BCLog::MEMPOOL, "orphanage overflow, removed %u tx\n", nEvicted);
@@ -228,7 +228,7 @@ void TxOrphanage::EraseForBlock(const CBlock& block)
             if (itByPrev == m_outpoint_to_orphan_it.end()) continue;
             for (auto mi = itByPrev->second.begin(); mi != itByPrev->second.end(); ++mi) {
                 const CTransaction& orphanTx = *(*mi)->second.tx;
-                const uint256& orphanHash = orphanTx.GetHash();
+                const uint256& orphanHash = orphanTx.GetWitnessHash();
                 vOrphanErase.push_back(orphanHash);
             }
         }

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -21,8 +21,14 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
     if (tx == nullptr) return false;
 
     const uint256& hash = tx->GetHash();
-    if (m_orphans.count(hash))
+    if (m_orphans.count(hash)) {
+        const auto ret = m_orphans.at(hash).announcers.insert(peer);
+        if (ret.second) {
+            m_peer_bytes_used.try_emplace(peer, 0);
+            m_peer_bytes_used.at(peer) += tx->GetTotalSize();
+        }
         return false;
+    }
 
     // Ignore big transactions, to avoid a
     // send-big-orphans memory exhaustion attack. If a peer has a legitimate
@@ -38,7 +44,7 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
         return false;
     }
 
-    auto ret = m_orphans.emplace(hash, OrphanTx{tx, peer, GetTime() + ORPHAN_TX_EXPIRE_TIME, m_orphan_list.size()});
+    auto ret = m_orphans.emplace(hash, OrphanTx{tx, GetTime() + ORPHAN_TX_EXPIRE_TIME, m_orphan_list.size(), {peer}});
     assert(ret.second);
     m_orphan_list.push_back(ret.first);
     // Allow for lookups in the orphan pool by wtxid, as well as txid
@@ -75,11 +81,12 @@ int TxOrphanage::_EraseTx(const uint256& wtxid)
     if (wtxid_it == m_wtxid_to_orphan_it.end()) return 0;
     std::map<uint256, OrphanTx>::iterator it = wtxid_it->second;
     m_total_orphan_bytes -= it->second.tx->GetTotalSize();
-    const auto peer{it->second.fromPeer};
-    Assume(m_peer_bytes_used.count(peer) > 0);
-    m_peer_bytes_used.at(peer) -= it->second.tx->GetTotalSize();
-    if (m_peer_bytes_used.at(peer) == 0) {
-        m_peer_bytes_used.erase(peer);
+    for (const auto peer : it->second.announcers) {
+        Assume(m_peer_bytes_used.count(peer) > 0);
+        m_peer_bytes_used.at(peer) -= it->second.tx->GetTotalSize();
+        if (m_peer_bytes_used.at(peer) == 0) {
+            m_peer_bytes_used.erase(peer);
+        }
     }
     for (const CTxIn& txin : it->second.tx->vin)
     {
@@ -106,6 +113,26 @@ int TxOrphanage::_EraseTx(const uint256& wtxid)
     m_orphans.erase(it);
     return 1;
 }
+void TxOrphanage::EraseOrphanOfPeer(const uint256& wtxid, NodeId peer)
+{
+    LOCK(m_mutex);
+    const auto wtxid_it = m_wtxid_to_orphan_it.find(wtxid);
+    if (wtxid_it == m_wtxid_to_orphan_it.end()) return;
+    std::map<uint256, OrphanTx>::iterator it = wtxid_it->second;
+    if (it->second.announcers.count(peer) > 0) {
+        if (it->second.announcers.size() == 1) {
+            _EraseTx(wtxid);
+        } else {
+            // Don't erase this orphan. Another peer has also announced it, so it may still be useful.
+            it->second.announcers.erase(peer);
+            Assume(m_peer_bytes_used.count(peer) > 0);
+            m_peer_bytes_used.at(peer) -= it->second.tx->GetTotalSize();
+            if (m_peer_bytes_used.at(peer) == 0) {
+                m_peer_bytes_used.erase(peer);
+            }
+        }
+    }
+}
 
 void TxOrphanage::EraseForPeer(NodeId peer)
 {
@@ -119,10 +146,14 @@ void TxOrphanage::EraseForPeer(NodeId peer)
     while (iter != m_orphans.end())
     {
         std::map<uint256, OrphanTx>::iterator maybeErase = iter++; // increment to avoid iterator becoming invalid
-        if (maybeErase->second.fromPeer == peer)
-        {
+        if (maybeErase->second.announcers.count(peer) > 0) {
             bytes_counted -= maybeErase->second.tx->GetTotalSize();
-            nErased += _EraseTx(maybeErase->second.tx->GetWitnessHash());
+            if (maybeErase->second.announcers.size() == 1) {
+                nErased += _EraseTx(maybeErase->second.tx->GetWitnessHash());
+            } else {
+                // Don't erase this orphan. Another peer has also announced it, so it may still be useful.
+                maybeErase->second.announcers.erase(peer);
+            }
         }
     }
     if (nErased > 0) LogPrint(BCLog::TXPACKAGES, "Erased %d orphan tx from peer=%d\n", nErased, peer);
@@ -182,13 +213,18 @@ void TxOrphanage::LimitOrphans(unsigned int max_orphans)
     FastRandomContext rng;
     while (m_orphans.size() > max_orphans || m_total_orphan_bytes > MAX_ORPHAN_TOTAL_SIZE)
     {
+        // Evict a random orphan not in any protected bucket. The set of protected peers may change
+        // each time an orphan is evicted.
         const auto protected_peers{_GetProtectedPeers()};
+        Assume(protected_peers.size() < m_peer_bytes_used.size());
         size_t randompos = rng.randrange(m_orphan_list.size());
-        while (protected_peers.count(m_orphan_list[randompos]->second.fromPeer) > 0) {
-            // skip protected orphans, try again
-            randompos = rng.randrange(m_orphan_list.size());
+        bool in_protected_bucket = true;
+        while (in_protected_bucket) {
+            const auto& announcers = m_orphan_list[randompos]->second.announcers;
+            in_protected_bucket = std::any_of(announcers.cbegin(), announcers.cend(),
+                                              [&](NodeId fromPeer) { return protected_peers.count(fromPeer) > 0; });
+            if (in_protected_bucket) randompos = rng.randrange(m_orphan_list.size());
         }
-        // Evict a random orphan:
         _EraseTx(m_orphan_list[randompos]->second.tx->GetWitnessHash());
         ++nEvicted;
     }
@@ -204,9 +240,13 @@ void TxOrphanage::AddChildrenToWorkSet(const CTransaction& tx)
         const auto it_by_prev = m_outpoint_to_orphan_it.find(COutPoint(tx.GetHash(), i));
         if (it_by_prev != m_outpoint_to_orphan_it.end()) {
             for (const auto& elem : it_by_prev->second) {
+                Assume(elem->second.announcers.size() >= 1);
+                if (elem->second.announcers.empty()) break;
+                // Pick the first peer from announcers set.
+                const auto peer = *elem->second.announcers.begin();
                 // Get this source peer's work set, emplacing an empty set if it didn't exist
                 // (note: if this peer wasn't still connected, we would have removed the orphan tx already)
-                std::set<uint256>& orphan_work_set = m_peer_work_set.try_emplace(elem->second.fromPeer).first->second;
+                std::set<uint256>& orphan_work_set = m_peer_work_set.try_emplace(peer).first->second;
                 // Add this tx to the work set
                 orphan_work_set.insert(elem->first);
             }

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -34,7 +34,7 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
     unsigned int sz = GetTransactionWeight(*tx);
     if (sz > MAX_STANDARD_TX_WEIGHT)
     {
-        LogPrint(BCLog::MEMPOOL, "ignoring large orphan tx (size: %u, hash: %s)\n", sz, hash.ToString());
+        LogPrint(BCLog::TXPACKAGES, "ignoring large orphan tx (size: %u, hash: %s)\n", sz, hash.ToString());
         return false;
     }
 
@@ -47,7 +47,7 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
         m_outpoint_to_orphan_it[txin.prevout].insert(ret.first);
     }
 
-    LogPrint(BCLog::MEMPOOL, "stored orphan tx %s (mapsz %u outsz %u)\n", hash.ToString(),
+    LogPrint(BCLog::TXPACKAGES, "stored orphan tx %s (mapsz %u outsz %u)\n", hash.ToString(),
              m_orphans.size(), m_outpoint_to_orphan_it.size());
     return true;
 }
@@ -113,7 +113,7 @@ void TxOrphanage::EraseForPeer(NodeId peer)
             nErased += _EraseTx(maybeErase->second.tx->GetWitnessHash());
         }
     }
-    if (nErased > 0) LogPrint(BCLog::MEMPOOL, "Erased %d orphan tx from peer=%d\n", nErased, peer);
+    if (nErased > 0) LogPrint(BCLog::TXPACKAGES, "Erased %d orphan tx from peer=%d\n", nErased, peer);
 }
 
 void TxOrphanage::LimitOrphans(unsigned int max_orphans)
@@ -139,7 +139,7 @@ void TxOrphanage::LimitOrphans(unsigned int max_orphans)
         }
         // Sweep again 5 minutes after the next entry that expires in order to batch the linear scan.
         nNextSweep = nMinExpTime + ORPHAN_TX_EXPIRE_INTERVAL;
-        if (nErased > 0) LogPrint(BCLog::MEMPOOL, "Erased %d orphan tx due to expiration\n", nErased);
+        if (nErased > 0) LogPrint(BCLog::TXPACKAGES, "Erased %d orphan tx due to expiration\n", nErased);
     }
     FastRandomContext rng;
     while (m_orphans.size() > max_orphans)
@@ -149,7 +149,7 @@ void TxOrphanage::LimitOrphans(unsigned int max_orphans)
         _EraseTx(m_orphan_list[randompos]->second.tx->GetWitnessHash());
         ++nEvicted;
     }
-    if (nEvicted > 0) LogPrint(BCLog::MEMPOOL, "orphanage overflow, removed %u tx\n", nEvicted);
+    if (nEvicted > 0) LogPrint(BCLog::TXPACKAGES, "orphanage overflow, removed %u tx\n", nEvicted);
 }
 
 void TxOrphanage::AddChildrenToWorkSet(const CTransaction& tx)
@@ -240,7 +240,7 @@ std::vector<uint256> TxOrphanage::EraseForBlock(const CBlock& block)
         for (const uint256& orphanHash : vOrphanErase) {
             nErased += _EraseTx(orphanHash);
         }
-        LogPrint(BCLog::MEMPOOL, "Erased %d orphan tx included or conflicted by block\n", nErased);
+        LogPrint(BCLog::TXPACKAGES, "Erased %d orphan tx included or conflicted by block\n", nErased);
     }
     return vOrphanErase;
 }

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -6,7 +6,6 @@
 
 #include <consensus/validation.h>
 #include <logging.h>
-#include <policy/policy.h>
 
 #include <cassert>
 
@@ -47,6 +46,7 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
         m_outpoint_to_orphan_it[txin.prevout].insert(ret.first);
     }
 
+    m_total_orphan_bytes += tx->GetTotalSize();
     LogPrint(BCLog::TXPACKAGES, "stored orphan tx %s (mapsz %u outsz %u)\n", hash.ToString(),
              m_orphans.size(), m_outpoint_to_orphan_it.size());
     return true;
@@ -71,6 +71,7 @@ int TxOrphanage::_EraseTx(const uint256& wtxid)
     const auto wtxid_it = m_wtxid_to_orphan_it.find(wtxid);
     if (wtxid_it == m_wtxid_to_orphan_it.end()) return 0;
     std::map<uint256, OrphanTx>::iterator it = wtxid_it->second;
+    m_total_orphan_bytes -= it->second.tx->GetTotalSize();
     for (const CTxIn& txin : it->second.tx->vin)
     {
         auto itPrev = m_outpoint_to_orphan_it.find(txin.prevout);
@@ -142,7 +143,7 @@ void TxOrphanage::LimitOrphans(unsigned int max_orphans)
         if (nErased > 0) LogPrint(BCLog::TXPACKAGES, "Erased %d orphan tx due to expiration\n", nErased);
     }
     FastRandomContext rng;
-    while (m_orphans.size() > max_orphans)
+    while (m_orphans.size() > max_orphans || m_total_orphan_bytes > MAX_ORPHAN_TOTAL_SIZE)
     {
         // Evict a random orphan:
         size_t randompos = rng.randrange(m_orphan_list.size());

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -46,6 +46,8 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
         m_outpoint_to_orphan_it[txin.prevout].insert(ret.first);
     }
 
+    m_peer_bytes_used.try_emplace(peer, 0);
+    m_peer_bytes_used.at(peer) += tx->GetTotalSize();
     m_total_orphan_bytes += tx->GetTotalSize();
     LogPrint(BCLog::TXPACKAGES, "stored orphan tx %s (mapsz %u outsz %u)\n", hash.ToString(),
              m_orphans.size(), m_outpoint_to_orphan_it.size());
@@ -72,6 +74,12 @@ int TxOrphanage::_EraseTx(const uint256& wtxid)
     if (wtxid_it == m_wtxid_to_orphan_it.end()) return 0;
     std::map<uint256, OrphanTx>::iterator it = wtxid_it->second;
     m_total_orphan_bytes -= it->second.tx->GetTotalSize();
+    const auto peer{it->second.fromPeer};
+    Assume(m_peer_bytes_used.count(peer) > 0);
+    m_peer_bytes_used.at(peer) -= it->second.tx->GetTotalSize();
+    if (m_peer_bytes_used.at(peer) == 0) {
+        m_peer_bytes_used.erase(peer);
+    }
     for (const CTxIn& txin : it->second.tx->vin)
     {
         auto itPrev = m_outpoint_to_orphan_it.find(txin.prevout);
@@ -105,16 +113,21 @@ void TxOrphanage::EraseForPeer(NodeId peer)
     m_peer_work_set.erase(peer);
 
     int nErased = 0;
+    size_t bytes_counted{m_peer_bytes_used.count(peer) ? m_peer_bytes_used.find(peer)->second : 0};
     std::map<uint256, OrphanTx>::iterator iter = m_orphans.begin();
     while (iter != m_orphans.end())
     {
         std::map<uint256, OrphanTx>::iterator maybeErase = iter++; // increment to avoid iterator becoming invalid
         if (maybeErase->second.fromPeer == peer)
         {
+            bytes_counted -= maybeErase->second.tx->GetTotalSize();
             nErased += _EraseTx(maybeErase->second.tx->GetWitnessHash());
         }
     }
     if (nErased > 0) LogPrint(BCLog::TXPACKAGES, "Erased %d orphan tx from peer=%d\n", nErased, peer);
+    // Either the peer didn't have any orphans, or the amount erased is equal to what the map was storing.
+    Assume(bytes_counted == 0);
+    m_peer_bytes_used.erase(peer);
 }
 
 void TxOrphanage::LimitOrphans(unsigned int max_orphans)

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -23,6 +23,9 @@ public:
     /** Add a new orphan transaction */
     bool AddTx(const CTransactionRef& tx, NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
+    /** Get orphan transaction by wtxid. Returns nullptr if we don't have it anymore. */
+    CTransactionRef GetTx(const uint256& wtxid) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+
     /** Check if we already have an orphan transaction (by txid or wtxid) */
     bool HaveTx(const GenTxid& gtxid) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -42,8 +42,8 @@ public:
     /** Erase all orphans announced by a peer (eg, after that peer disconnects) */
     void EraseForPeer(NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
-    /** Erase all orphans included in or invalidated by a new block */
-    void EraseForBlock(const CBlock& block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+    /** Erase all orphans included in or invalidated by a new block. Returns wtxids of erased txns. */
+    std::vector<uint256> EraseForBlock(const CBlock& block) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Limit the orphanage to the given maximum */
     void LimitOrphans(unsigned int max_orphans) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -36,8 +36,8 @@ public:
      */
     CTransactionRef GetTxToReconsider(NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
-    /** Erase an orphan by txid */
-    int EraseTx(const uint256& txid) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
+    /** Erase an orphan by wtxid */
+    int EraseTx(const uint256& wtxid) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);
 
     /** Erase all orphans announced by a peer (eg, after that peer disconnects) */
     void EraseForPeer(NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(!m_mutex);

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -6,12 +6,16 @@
 #define BITCOIN_TXORPHANAGE_H
 
 #include <net.h>
+#include <policy/policy.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <sync.h>
 
 #include <map>
 #include <set>
+
+/** Maximum total size of orphan transactions stored, in bytes. */
+static constexpr size_t MAX_ORPHAN_TOTAL_SIZE{100 * MAX_STANDARD_TX_WEIGHT};
 
 /** A class to track orphan transactions (failed on TX_MISSING_INPUTS)
  * Since we cannot distinguish orphans from bad transactions with
@@ -61,7 +65,16 @@ public:
         return m_orphans.size();
     }
 
+    /** Return total memory usage of the transactions stored. Does not include overhead of
+     * m_orphans, m_peer_work_set, etc. */
+    size_t TotalOrphanBytes() const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        LOCK(m_mutex);
+        return m_total_orphan_bytes;
+    }
 protected:
+    size_t m_total_orphan_bytes{0};
+
     /** Guards orphan transactions */
     mutable Mutex m_mutex;
 

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -72,6 +72,13 @@ public:
         LOCK(m_mutex);
         return m_total_orphan_bytes;
     }
+    size_t BytesFromPeer(NodeId peer) const EXCLUSIVE_LOCKS_REQUIRED(!m_mutex)
+    {
+        LOCK(m_mutex);
+        auto peer_bytes_it = m_peer_bytes_used.find(peer);
+        return peer_bytes_it == m_peer_bytes_used.end() ? 0 : peer_bytes_it->second;
+    }
+
 protected:
     size_t m_total_orphan_bytes{0};
 
@@ -113,6 +120,9 @@ protected:
     /** Index from wtxid into the m_orphans to lookup orphan
      *  transactions using their witness ids. */
     std::map<uint256, OrphanMap::iterator> m_wtxid_to_orphan_it GUARDED_BY(m_mutex);
+
+    /** Map from nodeid to the amount of orphans provided by this peer, in bytes. */
+    std::map<NodeId, size_t> m_peer_bytes_used GUARDED_BY(m_mutex);
 
     /** Erase an orphan by txid */
     int _EraseTx(const uint256& txid) EXCLUSIVE_LOCKS_REQUIRED(m_mutex);

--- a/src/txrequest.cpp
+++ b/src/txrequest.cpp
@@ -573,6 +573,17 @@ public:
         }
     }
 
+    std::vector<NodeId> GetCandidatePeers(const uint256& txhash) const
+    {
+        std::vector<NodeId> result_peers;
+        auto it = m_index.get<ByTxHash>().lower_bound(ByTxHashView{txhash, State::CANDIDATE_DELAYED, 0});
+        while (it != m_index.get<ByTxHash>().end() && it->m_txhash == txhash) {
+            if (it->GetState() != State::COMPLETED) result_peers.push_back(it->m_peer);
+            ++it;
+        }
+        return result_peers;
+    }
+
     void ReceivedInv(NodeId peer, const GenTxid& gtxid, bool preferred,
         std::chrono::microseconds reqtime)
     {
@@ -667,6 +678,21 @@ public:
         });
     }
 
+    void ResetRequestTimeout(NodeId peer, const uint256& txhash, std::chrono::microseconds new_expiry)
+    {
+        auto it = m_index.get<ByPeer>().find(ByPeerView{peer, false, txhash});
+        if (it == m_index.get<ByPeer>().end()) {
+            it = m_index.get<ByPeer>().find(ByPeerView{peer, true, txhash});
+        }
+        if (it == m_index.get<ByPeer>().end() || (it->GetState() != State::REQUESTED)) {
+            // There is no REQUESTED announcement tracked for this peer, so we have nothing to do.
+            return;
+        }
+        Modify<ByPeer>(it, [new_expiry](Announcement& ann) {
+            ann.m_time = new_expiry;
+        });
+    }
+
     void ReceivedResponse(NodeId peer, const uint256& txhash)
     {
         // We need to search the ByPeer index for both (peer, false, txhash) and (peer, true, txhash).
@@ -720,6 +746,7 @@ size_t TxRequestTracker::CountInFlight(NodeId peer) const { return m_impl->Count
 size_t TxRequestTracker::CountCandidates(NodeId peer) const { return m_impl->CountCandidates(peer); }
 size_t TxRequestTracker::Count(NodeId peer) const { return m_impl->Count(peer); }
 size_t TxRequestTracker::Size() const { return m_impl->Size(); }
+std::vector<NodeId> TxRequestTracker::GetCandidatePeers(const uint256& txhash) const { return m_impl->GetCandidatePeers(txhash); }
 void TxRequestTracker::SanityCheck() const { m_impl->SanityCheck(); }
 
 void TxRequestTracker::PostGetRequestableSanityCheck(std::chrono::microseconds now) const
@@ -736,6 +763,11 @@ void TxRequestTracker::ReceivedInv(NodeId peer, const GenTxid& gtxid, bool prefe
 void TxRequestTracker::RequestedTx(NodeId peer, const uint256& txhash, std::chrono::microseconds expiry)
 {
     m_impl->RequestedTx(peer, txhash, expiry);
+}
+
+void TxRequestTracker::ResetRequestTimeout(NodeId peer, const uint256& txhash, std::chrono::microseconds new_expiry)
+{
+    m_impl->ResetRequestTimeout(peer, txhash, new_expiry);
 }
 
 void TxRequestTracker::ReceivedResponse(NodeId peer, const uint256& txhash)

--- a/src/txrequest.h
+++ b/src/txrequest.h
@@ -173,6 +173,12 @@ public:
      */
     void RequestedTx(NodeId peer, const uint256& txhash, std::chrono::microseconds expiry);
 
+    /** For some already REQUESTED announcement, reset the expiry.
+     *
+     * If no REQUESTED announcement for the provided peer and txhash exists, this call has no effect.
+     */
+    void ResetRequestTimeout(NodeId peer, const uint256& txhash, std::chrono::microseconds new_expiry);
+
     /** Converts a CANDIDATE or REQUESTED announcement to a COMPLETED one. If no such announcement exists for the
      *  provided peer and txhash, nothing happens.
      *
@@ -194,6 +200,9 @@ public:
 
     /** Count how many announcements are being tracked in total across all peers and transaction hashes. */
     size_t Size() const;
+
+    /** For some tx hash (either txid or wtxid), return all peers with non-COMPLETED announcements. */
+    std::vector<NodeId> GetCandidatePeers(const uint256& txhash) const;
 
     /** Access to the internal priority computation (testing only) */
     uint64_t ComputePriority(const uint256& txhash, NodeId peer, bool preferred) const;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1396,6 +1396,21 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
     // the new transactions. This ensures we don't double-count transaction counts and sizes when
     // checking ancestor/descendant limits, or double-count transaction fees for fee-related policy.
     ATMPArgs single_args = ATMPArgs::SingleInPackageAccept(args);
+    const auto AcceptPackageWrappingSingle = [&](const std::vector<CTransactionRef>& subpackage)
+        EXCLUSIVE_LOCKS_REQUIRED(::cs_main, m_pool.cs) {
+        AssertLockHeld(::cs_main);
+        AssertLockHeld(m_pool.cs);
+        if (subpackage.size() > 1) {
+            return AcceptMultipleTransactions(subpackage, args);
+        }
+        const auto& tx = subpackage.front();
+        const auto single_res = AcceptSingleTransaction(tx, single_args);
+        PackageValidationState package_state_wrapped;
+        if (single_res.m_result_type != MempoolAcceptResult::ResultType::VALID) {
+            package_state_wrapped.Invalid(PackageValidationResult::PCKG_TX, "transaction failed");
+        }
+        return PackageMempoolAcceptResult(package_state_wrapped, {{tx->GetWitnessHash(), single_res}});
+    };
     // Results from individual validation. "Nonfinal" because if a transaction fails by itself but
     // succeeds later (i.e. when evaluated with a fee-bumping child), the result changes (though not
     // reflected in this map). If a transaction fails more than once, we want to return the first
@@ -1467,7 +1482,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
     }
     // Validate the (deduplicated) transactions as a package. Note that submission_result has its
     // own PackageValidationState; package_state_quit_early is unused past this point.
-    auto submission_result = AcceptMultipleTransactions(txns_package_eval, args);
+    auto submission_result = AcceptPackageWrappingSingle(txns_package_eval);
     // Include already-in-mempool transaction results in the final result.
     for (const auto& [wtxid, mempoolaccept_res] : results_final) {
         Assume(submission_result.m_tx_results.emplace(wtxid, mempoolaccept_res).second);
@@ -1475,7 +1490,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
     }
     if (submission_result.m_state.GetResult() == PackageValidationResult::PCKG_TX) {
         // Package validation failed because one or more transactions failed. Provide a result for
-        // each transaction; if AcceptMultipleTransactions() didn't return a result for a tx,
+        // each transaction; if a transaction doesn't have an entry in submission_result,
         // include the previous individual failure reason.
         submission_result.m_tx_results.insert(individual_results_nonfinal.cbegin(),
                                               individual_results_nonfinal.cend());

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -845,9 +845,18 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         return state.Invalid(TxValidationResult::TX_NOT_STANDARD, "bad-txns-too-many-sigops",
                 strprintf("%d", nSigOpsCost));
 
-    // No individual transactions are allowed below the min relay feerate and mempool min feerate except from
-    // disconnected blocks and transactions in a package. Package transactions will be checked using
-    // package feerate later.
+    // No individual transactions are allowed below the min relay feerate except from disconnected blocks.
+    // This requirement, unlike CheckFeeRate, cannot be bypassed using m_package_feerates because,
+    // while a tx could be package CPFP'd when entering the mempool, we do not have a DoS-resistant
+    // method of ensuring the tx remains bumped. For example, the fee-bumping child could disappear
+    // due to a replacement.
+    if (!bypass_limits && ws.m_modified_fees < m_pool.m_min_relay_feerate.GetFee(ws.m_vsize)) {
+        return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "min relay fee not met",
+                             strprintf("%d < %d", ws.m_modified_fees, m_pool.m_min_relay_feerate.GetFee(ws.m_vsize)));
+    }
+    // No individual transactions are allowed below the mempool min feerate except from disconnected
+    // blocks and transactions in a package. Package transactions will be checked using package
+    // feerate later.
     if (!bypass_limits && !args.m_package_feerates && !CheckFeeRate(ws.m_vsize, ws.m_modified_fees, state)) return false;
 
     ws.m_iters_conflicting = m_pool.GetIterSet(ws.m_conflicts);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -655,11 +655,11 @@ private:
         AssertLockHeld(m_pool.cs);
         CAmount mempoolRejectFee = m_pool.GetMinFee().GetFee(package_size);
         if (mempoolRejectFee > 0 && package_fee < mempoolRejectFee) {
-            return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "mempool min fee not met", strprintf("%d < %d", package_fee, mempoolRejectFee));
+            return state.Invalid(TxValidationResult::TX_LOW_FEE, "mempool min fee not met", strprintf("%d < %d", package_fee, mempoolRejectFee));
         }
 
         if (package_fee < m_pool.m_min_relay_feerate.GetFee(package_size)) {
-            return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "min relay fee not met",
+            return state.Invalid(TxValidationResult::TX_LOW_FEE, "min relay fee not met",
                                  strprintf("%d < %d", package_fee, m_pool.m_min_relay_feerate.GetFee(package_size)));
         }
         return true;
@@ -851,7 +851,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     // method of ensuring the tx remains bumped. For example, the fee-bumping child could disappear
     // due to a replacement.
     if (!bypass_limits && ws.m_modified_fees < m_pool.m_min_relay_feerate.GetFee(ws.m_vsize)) {
-        return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "min relay fee not met",
+        return state.Invalid(TxValidationResult::TX_LOW_FEE, "min relay fee not met",
                              strprintf("%d < %d", ws.m_modified_fees, m_pool.m_min_relay_feerate.GetFee(ws.m_vsize)));
     }
     // No individual transactions are allowed below the mempool min feerate except from disconnected
@@ -960,7 +960,7 @@ bool MemPoolAccept::ReplacementChecks(Workspace& ws)
     //   descendant transaction of a direct conflict to pay a higher feerate than the transaction that
     //   might replace them, under these rules.
     if (const auto err_string{PaysMoreThanConflicts(ws.m_iters_conflicting, newFeeRate, hash)}) {
-        return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "insufficient fee", *err_string);
+        return state.Invalid(TxValidationResult::TX_LOW_FEE, "insufficient fee", *err_string);
     }
 
     // Calculate all conflicting entries and enforce Rule #5.
@@ -981,7 +981,7 @@ bool MemPoolAccept::ReplacementChecks(Workspace& ws)
     }
     if (const auto err_string{PaysForRBF(ws.m_conflicting_fees, ws.m_modified_fees, ws.m_vsize,
                                          m_pool.m_incremental_relay_feerate, hash)}) {
-        return state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "insufficient fee", *err_string);
+        return state.Invalid(TxValidationResult::TX_LOW_FEE, "insufficient fee", *err_string);
     }
     return true;
 }
@@ -1456,6 +1456,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
             if (single_res_it != subpackage_result.m_tx_results.end()) {
                 const auto single_res = single_res_it->second;
                 if (single_res.m_state.GetResult() != TxValidationResult::TX_MEMPOOL_POLICY &&
+                    single_res.m_state.GetResult() != TxValidationResult::TX_LOW_FEE &&
                     single_res.m_state.GetResult() != TxValidationResult::TX_MISSING_INPUTS) {
                     // Package validation policy only differs from individual policy in its evaluation
                     // of feerate. For example, if a transaction fails here due to violation of a

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1246,7 +1246,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
 
     // These context-free package limits can be done before taking the mempool lock.
     PackageValidationState package_state;
-    if (!CheckPackage(txns, package_state)) return PackageMempoolAcceptResult(package_state, {});
+    if (!IsPackageWellFormed(txns, package_state)) return PackageMempoolAcceptResult(package_state, {});
 
     std::vector<Workspace> workspaces{};
     workspaces.reserve(txns.size());
@@ -1339,7 +1339,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
     // transactions and thus won't return any MempoolAcceptResults, just a package-wide error.
 
     // Context-free package checks.
-    if (!CheckPackage(package, package_state_quit_early)) return PackageMempoolAcceptResult(package_state_quit_early, {});
+    if (!IsPackageWellFormed(package, package_state_quit_early)) return PackageMempoolAcceptResult(package_state_quit_early, {});
 
     // All transactions in the package must be a parent of the last transaction. This is just an
     // opportunity for us to fail fast on a context-free check without taking the mempool lock.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1200,6 +1200,7 @@ bool MemPoolAccept::SubmitPackage(const ATMPArgs& args, std::vector<Workspace>& 
         } else {
             all_submitted = false;
             ws.m_state.Invalid(TxValidationResult::TX_MEMPOOL_POLICY, "mempool full");
+            package_state.Invalid(PackageValidationResult::PCKG_TX, "transaction failed");
             results.emplace(ws.m_ptx->GetWitnessHash(), MempoolAcceptResult::Failure(ws.m_state));
         }
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1319,6 +1319,14 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
         }
     }
 
+    if (args.m_package_feerates) {
+        // The only valid fee bump between transactions is CPFP (or more generally, a tx should only
+        // be able to bump ancestors).  The use of aggregate package feerate is assuming
+        // transactions would not be submitted as a package if they would have passed the feerate
+        // checks on their own. Check this assumption; the aggregate package feerate should not be
+        // higher than the feerate of the last transaction, which is the "child" or "sponsor."
+        Assume(CFeeRate(workspaces.back().m_modified_fees, workspaces.back().m_vsize) >= package_feerate);
+    }
     if (args.m_test_accept) return PackageMempoolAcceptResult(package_state, std::move(results));
 
     if (!SubmitPackage(args, workspaces, package_state, results)) {
@@ -1417,8 +1425,6 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
     // reflected in this map). If a transaction fails more than once, we want to return the first
     // result, when it was considered on its own. So changes will only be from invalid -> valid.
     std::map<uint256, MempoolAcceptResult> individual_results_nonfinal;
-    bool quit_early{false};
-    std::vector<CTransactionRef> txns_package_eval;
     for (const auto& tx : packageified.Txns()) {
         const auto& wtxid = tx->GetWitnessHash();
         const auto& txid = tx->GetHash();
@@ -1448,7 +1454,6 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
             // Transaction does not already exist in the mempool.
             const auto subpackage = packageified.GetAncestorSet(tx);
             if (!subpackage) {
-                Assume(quit_early);
                 // This transaction depends on a tx we will definitely not accept (failed for a
                 // non-policy and non-missing-inputs reason). We already know that this transaction
                 // will be invalid for at least one reason, i.e. a missing input. To minimize the
@@ -1460,36 +1465,56 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
                 // parent, and should still be considered.
                 continue;
             }
-            // Try submitting the transaction on its own.
-            const auto single_res = AcceptSingleTransaction(tx, single_args);
-            if (single_res.m_result_type == MempoolAcceptResult::ResultType::VALID) {
-                // The transaction succeeded on its own and is now in the mempool. Don't include it
-                // in package validation, because its fees should only be "used" once.
-                assert(m_pool.exists(GenTxid::Wtxid(wtxid)));
-                results_final.emplace(wtxid, single_res);
-                packageified.Exclude(tx);
-            } else if (single_res.m_state.GetResult() != TxValidationResult::TX_MEMPOOL_POLICY &&
-                       single_res.m_state.GetResult() != TxValidationResult::TX_MISSING_INPUTS) {
-                // Package validation policy only differs from individual policy in its evaluation
-                // of feerate. For example, if a transaction fails here due to violation of a
-                // consensus rule, the result will not change when it is submitted as part of a
-                // package. Tell the Packageifier that subsequent transactions depending on this one
-                // should be skipped.
-                quit_early = true;
-                package_state_quit_early.Invalid(PackageValidationResult::PCKG_TX, "transaction failed");
+            // This transaction does not already exist in the mempool and is not the child.
+            // Try submitting the transaction with its in-package ancestor set.
+            const auto subpackage_result = AcceptPackageWrappingSingle(subpackage.value());
+            // Look for "final" answers: once a tx is successfully submitted, we can add its
+            // MempoolAcceptResult to the results map. Note that it's possible for transactions to
+            // have been submitted to the mempool even if subpackage_result.m_state.IsInvalid().
+            for (const auto& subpackage_tx : subpackage.value()) {
+                const auto subpackage_wtxid{subpackage_tx->GetWitnessHash()};
+                if (m_pool.exists(GenTxid::Wtxid(subpackage_wtxid))) {
+                    const auto subpackage_it{subpackage_result.m_tx_results.find(subpackage_wtxid)};
+                    results_final.emplace(subpackage_wtxid, subpackage_it->second);
+                    // Erase any previous invalid results for this transaction. For example, this
+                    // could be a low-feerate tx that has just been bumped.
+                    individual_results_nonfinal.erase(subpackage_wtxid);
+                    packageified.Exclude(subpackage_tx);
+                }
+            }
+            // If m_state is valid, we already processed each tx in the loop above.
+            if (subpackage_result.m_state.IsValid()) continue;
+
+            const auto single_res_it = subpackage_result.m_tx_results.find(wtxid);
+            if (single_res_it != subpackage_result.m_tx_results.end()) {
+                const auto single_res = single_res_it->second;
+                if (single_res.m_state.GetResult() != TxValidationResult::TX_MEMPOOL_POLICY &&
+                    single_res.m_state.GetResult() != TxValidationResult::TX_MISSING_INPUTS) {
+                    // Package validation policy only differs from individual policy in its evaluation
+                    // of feerate. For example, if a transaction fails here due to violation of a
+                    // consensus rule, the result will not change when it is submitted as part of a
+                    // package. Tell the Packageifier that subsequent transactions depending on this one
+                    // should be skipped.
+                    package_state_quit_early.Invalid(PackageValidationResult::PCKG_TX, "transaction failed");
+                    individual_results_nonfinal.emplace(wtxid, single_res);
+                    packageified.Ban(tx);
+                }
                 individual_results_nonfinal.emplace(wtxid, single_res);
-                packageified.Ban(tx);
-            } else {
-                individual_results_nonfinal.emplace(wtxid, single_res);
-                txns_package_eval.push_back(tx);
+            } else if (subpackage->size() > 1) {
+                // This transaction didn't get a result because it depends on another transaction
+                // that failed (PCKG_POLICY or AcceptMultipleTransactions() quit early on a previous
+                // transaction). Its error is missing inputs.
+                TxValidationState tx_state_dependent;
+                tx_state_dependent.Invalid(TxValidationResult::TX_MISSING_INPUTS, "bad-txns-inputs-missingorspent");
+                individual_results_nonfinal.emplace(wtxid, MempoolAcceptResult::Failure(tx_state_dependent));
             }
         }
     }
 
-    // Quit early because package validation won't change the result or the entire package has
-    // already been submitted.
+    const auto txns_package_eval{packageified.GetAncestorSet(child)};
+    // If txns_package_eval is std::nullopt, the last tx's result was pre-filled.
     // If txns_package_eval is empty, all transactions have already passed.
-    if (quit_early || txns_package_eval.empty()) {
+    if (!txns_package_eval || txns_package_eval->empty()) {
         for (const auto& [wtxid, mempoolaccept_res] : individual_results_nonfinal) {
             Assume(results_final.emplace(wtxid, mempoolaccept_res).second);
             Assume(mempoolaccept_res.m_result_type == MempoolAcceptResult::ResultType::INVALID);
@@ -1498,7 +1523,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
     }
     // Validate the (deduplicated) transactions as a package. Note that submission_result has its
     // own PackageValidationState; package_state_quit_early is unused past this point.
-    auto submission_result = AcceptPackageWrappingSingle(txns_package_eval);
+    auto submission_result = AcceptPackageWrappingSingle(txns_package_eval.value());
     // Include already-in-mempool transaction results in the final result.
     for (const auto& [wtxid, mempoolaccept_res] : results_final) {
         Assume(submission_result.m_tx_results.emplace(wtxid, mempoolaccept_res).second);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1411,6 +1411,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
         }
         return PackageMempoolAcceptResult(package_state_wrapped, {{tx->GetWitnessHash(), single_res}});
     };
+    Packageifier packageified(package);
     // Results from individual validation. "Nonfinal" because if a transaction fails by itself but
     // succeeds later (i.e. when evaluated with a fee-bumping child), the result changes (though not
     // reflected in this map). If a transaction fails more than once, we want to return the first
@@ -1418,7 +1419,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
     std::map<uint256, MempoolAcceptResult> individual_results_nonfinal;
     bool quit_early{false};
     std::vector<CTransactionRef> txns_package_eval;
-    for (const auto& tx : package) {
+    for (const auto& tx : packageified.Txns()) {
         const auto& wtxid = tx->GetWitnessHash();
         const auto& txid = tx->GetHash();
         // There are 3 possibilities: already in mempool, same-txid-diff-wtxid already in mempool,
@@ -1429,6 +1430,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
             auto iter = m_pool.GetIter(txid);
             assert(iter != std::nullopt);
             results_final.emplace(wtxid, MempoolAcceptResult::MempoolTx(iter.value()->GetTxSize(), iter.value()->GetFee()));
+            packageified.Exclude(tx);
         } else if (m_pool.exists(GenTxid::Txid(txid))) {
             // Transaction with the same non-witness data but different witness (same txid,
             // different wtxid) already exists in the mempool.
@@ -1441,8 +1443,23 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
             assert(iter != std::nullopt);
             // Provide the wtxid of the mempool tx so that the caller can look it up in the mempool.
             results_final.emplace(wtxid, MempoolAcceptResult::MempoolTxDifferentWitness(iter.value()->GetTx().GetWitnessHash()));
+            packageified.Exclude(tx);
         } else {
             // Transaction does not already exist in the mempool.
+            const auto subpackage = packageified.GetAncestorSet(tx);
+            if (!subpackage) {
+                Assume(quit_early);
+                // This transaction depends on a tx we will definitely not accept (failed for a
+                // non-policy and non-missing-inputs reason). We already know that this transaction
+                // will be invalid for at least one reason, i.e. a missing input. To minimize the
+                // amount of repeated work, don't validate this tx. Just return missing inputs.
+                TxValidationState tx_state_quit_early;
+                tx_state_quit_early.Invalid(TxValidationResult::TX_MISSING_INPUTS, "bad-txns-inputs-missingorspent");
+                individual_results_nonfinal.emplace(wtxid, MempoolAcceptResult::Failure(tx_state_quit_early));
+                // Don't quit too early. Other transactions may not necessarily depend on the same
+                // parent, and should still be considered.
+                continue;
+            }
             // Try submitting the transaction on its own.
             const auto single_res = AcceptSingleTransaction(tx, single_args);
             if (single_res.m_result_type == MempoolAcceptResult::ResultType::VALID) {
@@ -1450,20 +1467,18 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
                 // in package validation, because its fees should only be "used" once.
                 assert(m_pool.exists(GenTxid::Wtxid(wtxid)));
                 results_final.emplace(wtxid, single_res);
+                packageified.Exclude(tx);
             } else if (single_res.m_state.GetResult() != TxValidationResult::TX_MEMPOOL_POLICY &&
                        single_res.m_state.GetResult() != TxValidationResult::TX_MISSING_INPUTS) {
                 // Package validation policy only differs from individual policy in its evaluation
                 // of feerate. For example, if a transaction fails here due to violation of a
                 // consensus rule, the result will not change when it is submitted as part of a
-                // package. To minimize the amount of repeated work, unless the transaction fails
-                // due to feerate or missing inputs (its parent is a previous transaction in the
-                // package that failed due to feerate), don't run package validation. Note that this
-                // decision might not make sense if different types of packages are allowed in the
-                // future.  Continue individually validating the rest of the transactions, because
-                // some of them may still be valid.
+                // package. Tell the Packageifier that subsequent transactions depending on this one
+                // should be skipped.
                 quit_early = true;
                 package_state_quit_early.Invalid(PackageValidationResult::PCKG_TX, "transaction failed");
                 individual_results_nonfinal.emplace(wtxid, single_res);
+                packageified.Ban(tx);
             } else {
                 individual_results_nonfinal.emplace(wtxid, single_res);
                 txns_package_eval.push_back(tx);
@@ -1473,6 +1488,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
 
     // Quit early because package validation won't change the result or the entire package has
     // already been submitted.
+    // If txns_package_eval is empty, all transactions have already passed.
     if (quit_early || txns_package_eval.empty()) {
         for (const auto& [wtxid, mempoolaccept_res] : individual_results_nonfinal) {
             Assume(results_final.emplace(wtxid, mempoolaccept_res).second);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1246,7 +1246,7 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
 
     // These context-free package limits can be done before taking the mempool lock.
     PackageValidationState package_state;
-    if (!IsPackageWellFormed(txns, package_state)) return PackageMempoolAcceptResult(package_state, {});
+    if (!IsPackageWellFormed(txns, package_state, /*require_sorted=*/true)) return PackageMempoolAcceptResult(package_state, {});
 
     std::vector<Workspace> workspaces{};
     workspaces.reserve(txns.size());
@@ -1345,52 +1345,20 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
 
     // Check that the package is well-formed. If it isn't, we won't try to validate any of the
     // transactions and thus won't return any MempoolAcceptResults, just a package-wide error.
-
     // Context-free package checks.
-    if (!IsPackageWellFormed(package, package_state_quit_early)) return PackageMempoolAcceptResult(package_state_quit_early, {});
-
-    // All transactions in the package must be a parent of the last transaction. This is just an
-    // opportunity for us to fail fast on a context-free check without taking the mempool lock.
-    if (!IsChildWithParents(package)) {
-        package_state_quit_early.Invalid(PackageValidationResult::PCKG_POLICY, "package-not-child-with-parents");
+    if (!package.empty() && !IsPackageWellFormed(package, package_state_quit_early, /*require_sorted=*/false)) {
         return PackageMempoolAcceptResult(package_state_quit_early, {});
     }
-
-    // IsChildWithParents() guarantees the package is > 1 transactions.
-    assert(package.size() > 1);
-    // The package must be 1 child with all of its unconfirmed parents. The package is expected to
-    // be sorted, so the last transaction is the child.
+    // Sorts the package and calculate ancestor subpackages.
+    Packageifier packageified(package);
     const auto& child = package.back();
-    std::unordered_set<uint256, SaltedTxidHasher> unconfirmed_parent_txids;
-    std::transform(package.cbegin(), package.cend() - 1,
-                   std::inserter(unconfirmed_parent_txids, unconfirmed_parent_txids.end()),
-                   [](const auto& tx) { return tx->GetHash(); });
-
-    // All child inputs must refer to a preceding package transaction or a confirmed UTXO. The only
-    // way to verify this is to look up the child's inputs in our current coins view (not including
-    // mempool), and enforce that all parents not present in the package be available at chain tip.
-    // Since this check can bring new coins into the coins cache, keep track of these coins and
-    // uncache them if we don't end up submitting this package to the mempool.
-    const CCoinsViewCache& coins_tip_cache = m_active_chainstate.CoinsTip();
-    for (const auto& input : child->vin) {
-        if (!coins_tip_cache.HaveCoinInCache(input.prevout)) {
-            args.m_coins_to_uncache.push_back(input.prevout);
-        }
-    }
-    // Using the MemPoolAccept m_view cache allows us to look up these same coins faster later.
-    // This should be connecting directly to CoinsTip, not to m_viewmempool, because we specifically
-    // require inputs to be confirmed if they aren't in the package.
-    m_view.SetBackend(m_active_chainstate.CoinsTip());
-    const auto package_or_confirmed = [this, &unconfirmed_parent_txids](const auto& input) {
-         return unconfirmed_parent_txids.count(input.prevout.hash) > 0 || m_view.HaveCoin(input.prevout);
-    };
-    if (!std::all_of(child->vin.cbegin(), child->vin.cend(), package_or_confirmed)) {
-        package_state_quit_early.Invalid(PackageValidationResult::PCKG_POLICY, "package-not-child-with-unconfirmed-parents");
+    const auto child_subpackage = packageified.GetAncestorSet(child);
+    // If this is an ancestor package, the last transaction's ancestor set should be the
+    // entire package.
+    if (child_subpackage == std::nullopt || child_subpackage.value().size() != package.size()) {
+        package_state_quit_early.Invalid(PackageValidationResult::PCKG_POLICY, "not-ancestor-package");
         return PackageMempoolAcceptResult(package_state_quit_early, {});
     }
-    // Protect against bugs where we pull more inputs from disk that miss being added to
-    // coins_to_uncache. The backend will be connected again when needed in PreChecks.
-    m_view.SetBackend(m_dummy);
 
     LOCK(m_pool.cs);
     // Stores final results that won't change
@@ -1419,7 +1387,6 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptPackage(const Package& package, 
         }
         return PackageMempoolAcceptResult(package_state_wrapped, {{tx->GetWitnessHash(), single_res}});
     };
-    Packageifier packageified(package);
     // Results from individual validation. "Nonfinal" because if a transaction fails by itself but
     // succeeds later (i.e. when evaluated with a fee-bumping child), the result changes (though not
     // reflected in this map). If a transaction fails more than once, we want to return the first

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -13,6 +13,7 @@ from test_framework.util import (
     assert_equal,
     assert_fee_amount,
     assert_greater_than,
+    assert_greater_than_or_equal,
     assert_raises_rpc_error,
     create_lots_of_big_transactions,
     gen_return_txouts,
@@ -27,10 +28,13 @@ from test_framework.wallet import (
 class MempoolLimitTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
-        self.num_nodes = 1
+        self.num_nodes = 2
         self.extra_args = [[
             "-datacarriersize=100000",
             "-maxmempool=5",
+        ],
+        [
+            "-datacarriersize=100000",
         ]]
         self.supports_cli = False
 
@@ -39,25 +43,31 @@ class MempoolLimitTest(BitcoinTestFramework):
         node = self.nodes[0]
         miniwallet = MiniWallet(node)
         relayfee = node.getnetworkinfo()['relayfee']
+        all_transactions = []
 
         self.log.info('Check that mempoolminfee is minrelaytxfee')
         assert_equal(node.getmempoolinfo()['minrelaytxfee'], Decimal('0.00001000'))
         assert_equal(node.getmempoolinfo()['mempoolminfee'], Decimal('0.00001000'))
 
-        tx_batch_size = 25
-        num_of_batches = 3
+        # Batch size 1 is required to ensure every tx has a different feerate, which means the
+        # selection of transaction(s) for eviction is identical across nodes.
+        tx_batch_size = 1
+        num_of_batches = 75
         # Generate UTXOs to flood the mempool
         # 1 to create a tx initially that will be evicted from the mempool later
-        # 3 batches of multiple transactions with a fee rate much higher than the previous UTXO
+        # 75 transactions, each with a fee rate much higher than the previous one
         # And 1 more to verify that this tx does not get added to the mempool with a fee rate less than the mempoolminfee
         # And 2 more for the package cpfp test
         self.generate(miniwallet, 1 + (num_of_batches * tx_batch_size) + 1 + 2)
 
         # Mine 99 blocks so that the UTXOs are allowed to be spent
         self.generate(node, COINBASE_MATURITY - 1)
+        self.disconnect_nodes(0, 1)
 
         self.log.info('Create a mempool tx that will be evicted')
-        tx_to_be_evicted_id = miniwallet.send_self_transfer(from_node=node, fee_rate=relayfee)["txid"]
+        tx_to_be_evicted = miniwallet.send_self_transfer(from_node=node, fee_rate=relayfee)
+        tx_to_be_evicted_id = tx_to_be_evicted["txid"]
+        all_transactions.append(tx_to_be_evicted["hex"])
 
         # Increase the tx fee rate to give the subsequent transactions a higher priority in the mempool
         # The tx has an approx. vsize of 65k, i.e. multiplying the previous fee rate (in sats/kvB)
@@ -67,7 +77,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         self.log.info("Fill up the mempool with txs with higher fee rate")
         for batch_of_txid in range(num_of_batches):
             fee = (batch_of_txid + 1) * base_fee
-            create_lots_of_big_transactions(miniwallet, node, fee, tx_batch_size, txouts)
+            all_transactions.extend(create_lots_of_big_transactions(miniwallet, node, fee, tx_batch_size, txouts)[1])
 
         self.log.info('The tx should be evicted by now')
         # The number of transactions created should be greater than the ones present in the mempool
@@ -81,7 +91,9 @@ class MempoolLimitTest(BitcoinTestFramework):
 
         # Deliberately try to create a tx with a fee less than the minimum mempool fee to assert that it does not get added to the mempool
         self.log.info('Create a mempool tx that will not pass mempoolminfee')
-        assert_raises_rpc_error(-26, "mempool min fee not met", miniwallet.send_self_transfer, from_node=node, fee_rate=relayfee)
+        tx_below_mempoolmin = miniwallet.create_self_transfer(fee_rate=relayfee)
+        assert_raises_rpc_error(-26, "mempool min fee not met", node.sendrawtransaction, tx_below_mempoolmin["hex"])
+        all_transactions.append(tx_below_mempoolmin["hex"])
 
         self.log.info("Check that submitpackage allows cpfp of a parent below mempool min feerate")
         node = self.nodes[0]
@@ -116,10 +128,41 @@ class MempoolLimitTest(BitcoinTestFramework):
         assert_fee_amount(package_fees, package_vsize, child_result["fees"]["effective-feerate"])
         assert_equal([tx_poor["wtxid"], tx_child["tx"].getwtxid()], poor_parent_result["fees"]["effective-includes"])
         assert_equal([tx_poor["wtxid"], tx_child["tx"].getwtxid()], child_result["fees"]["effective-includes"])
+        assert_greater_than_or_equal(poor_parent_result["fees"]["effective-feerate"], Decimal("0.0002"))
 
         # The node will broadcast each transaction, still abiding by its peer's fee filter
         peer.wait_for_broadcast([tx["tx"].getwtxid() for tx in package_txns])
-        self.generate(node, 1)
+        kept_txids = set(node.getrawmempool())
+
+        self.log.info('Test restarting with smaller maxmempool persists the correct transactions.')
+        # All transactions would make it in to a default size mempool:
+        self.nodes[1].prioritisetransaction(tx_rich["txid"], 0, int(DEFAULT_FEE * COIN))
+        for txhex in all_transactions:
+            self.nodes[1].sendrawtransaction(txhex)
+        self.nodes[1].submitpackage([tx["hex"] for tx in package_txns])
+        node1_info = self.nodes[1].getmempoolinfo()
+        assert_equal(node1_info["mempoolminfee"], node1_info["minrelaytxfee"])
+        self.stop_node(1)
+        # Upon restart, the mempool min fee will rise above 1sat/vB due to the limited capacity.
+        self.restart_node(1, extra_args=["-maxmempool=5","-datacarriersize=100000"])
+        node1_info_after_restart = self.nodes[1].getmempoolinfo()
+        assert_greater_than(node1_info_after_restart["mempoolminfee"], node1_info_after_restart["minrelaytxfee"])
+        assert_equal(set(self.nodes[1].getrawmempool()), kept_txids)
+
+        txids_above_20 = set()
+        for txid in kept_txids:
+            entry = self.nodes[1].getmempoolentry(txid)
+            descendant_feerate = Decimal(entry["fees"]["descendant"] / entry["descendantsize"])
+            assert_greater_than_or_equal(descendant_feerate * 1000, node1_info_after_restart["mempoolminfee"])
+            if (descendant_feerate * 1000 >= Decimal("0.0002")):
+                txids_above_20.add(txid)
+        assert all([tx["txid"] in txids_above_20 for tx in package_txns])
+
+        self.log.info('Test restarting with higher -minrelaytxfee persists the correct transactions.')
+        self.stop_node(1)
+        self.restart_node(1, extra_args=["-minrelaytxfee=0.0002","-datacarriersize=100000"])
+        assert_equal(set(self.nodes[1].getrawmempool()), txids_above_20)
+
 
         self.log.info('Test passing a value below the minimum (5 MB) to -maxmempool throws an error')
         self.stop_node(0)

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -152,7 +152,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
                 (i+1) * base_fee,
                 end_range - start_range,
                 self.txouts,
-                utxos[start_range:end_range])
+                utxos[start_range:end_range])[0]
 
         # Make sure that the size of each group of transactions exceeds
         # MAX_BLOCK_WEIGHT // 4 -- otherwise the test needs to be revised to

--- a/test/functional/p2p_package_relay.py
+++ b/test/functional/p2p_package_relay.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test package relay messages"""
+
+import time
+
+from test_framework.messages import (
+    msg_sendpackages,
+    msg_verack,
+    msg_wtxidrelay,
+)
+from test_framework.p2p import (
+    p2p_lock,
+    P2PTxInvStore,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+)
+
+def cleanup(func):
+    def wrapper(self):
+        try:
+            func(self)
+        finally:
+            # Clear mempool
+            self.generate(self.nodes[0], 1)
+            self.nodes[0].disconnect_p2ps()
+            self.nodes[0].setmocktime(int(time.time()))
+    return wrapper
+
+class PackageRelayer(P2PTxInvStore):
+    def __init__(self, send_sendpackages=True, send_wtxidrelay=True):
+        super().__init__()
+        # List versions of each sendpackages received
+        self._sendpackages_received = []
+        self._send_sendpackages = send_sendpackages
+        self._send_wtxidrelay = send_wtxidrelay
+
+    @property
+    def sendpackages_received(self):
+        with p2p_lock:
+            return self._sendpackages_received
+
+    def on_version(self, message):
+        if self._send_wtxidrelay:
+            self.send_message(msg_wtxidrelay())
+        if self._send_sendpackages:
+            self.send_message(msg_sendpackages())
+        self.send_message(msg_verack())
+        self.nServices = message.nServices
+
+    def on_sendpackages(self, message):
+        self._sendpackages_received.append(message.version)
+
+class PackageRelayTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [["-packagerelay=1"]]
+
+    @cleanup
+    def test_sendpackages(self):
+        self.log.info("Test sendpackages during version handshake")
+        node = self.nodes[0]
+        peer_normal = node.add_p2p_connection(PackageRelayer())
+        assert_equal(node.getpeerinfo()[0]["bytesrecv_per_msg"]["sendpackages"], 28)
+        assert_equal(node.getpeerinfo()[0]["bytessent_per_msg"]["sendpackages"], 28)
+        assert_equal(peer_normal.sendpackages_received, [0])
+        peer_normal.peer_disconnect()
+
+        self.log.info("Test sendpackages without wtxid relay")
+        node = self.nodes[0]
+        peer_no_wtxidrelay = node.add_p2p_connection(PackageRelayer(send_wtxidrelay=False))
+        assert_equal(node.getpeerinfo()[0]["bytesrecv_per_msg"]["sendpackages"], 28)
+        assert_equal(node.getpeerinfo()[0]["bytessent_per_msg"]["sendpackages"], 28)
+        assert_equal(peer_no_wtxidrelay.sendpackages_received, [0])
+        peer_no_wtxidrelay.peer_disconnect()
+
+        self.log.info("Test sendpackages is sent even so")
+        node = self.nodes[0]
+        peer_no_sendpackages = node.add_p2p_connection(PackageRelayer(send_sendpackages=False))
+        # Sendpackages should still be sent
+        assert_equal(node.getpeerinfo()[0]["bytessent_per_msg"]["sendpackages"], 28)
+        assert "sendpackages" not in node.getpeerinfo()[0]["bytesrecv_per_msg"]
+        assert_equal(peer_no_sendpackages.sendpackages_received, [0])
+        peer_no_sendpackages.peer_disconnect()
+
+        self.log.info("Test disconnection if sendpackages is sent after version handshake")
+        peer_sendpackages_after_verack = node.add_p2p_connection(P2PTxInvStore())
+        peer_sendpackages_after_verack.send_message(msg_sendpackages())
+        peer_sendpackages_after_verack.wait_for_disconnect()
+
+    def run_test(self):
+        self.test_sendpackages()
+
+if __name__ == '__main__':
+    PackageRelayTest().main()

--- a/test/functional/p2p_package_relay.py
+++ b/test/functional/p2p_package_relay.py
@@ -67,8 +67,9 @@ class PackageRelayTest(BitcoinTestFramework):
         peer_normal = node.add_p2p_connection(PackageRelayer())
         assert_equal(node.getpeerinfo()[0]["bytesrecv_per_msg"]["sendpackages"], 28)
         assert_equal(node.getpeerinfo()[0]["bytessent_per_msg"]["sendpackages"], 28)
+        assert node.getpeerinfo()[0]["relaytxpackages"]
         assert_equal(peer_normal.sendpackages_received, [0])
-        peer_normal.peer_disconnect()
+        node.disconnect_p2ps()
 
         self.log.info("Test sendpackages without wtxid relay")
         node = self.nodes[0]
@@ -76,7 +77,8 @@ class PackageRelayTest(BitcoinTestFramework):
         assert_equal(node.getpeerinfo()[0]["bytesrecv_per_msg"]["sendpackages"], 28)
         assert_equal(node.getpeerinfo()[0]["bytessent_per_msg"]["sendpackages"], 28)
         assert_equal(peer_no_wtxidrelay.sendpackages_received, [0])
-        peer_no_wtxidrelay.peer_disconnect()
+        assert not node.getpeerinfo()[0]["relaytxpackages"]
+        node.disconnect_p2ps()
 
         self.log.info("Test sendpackages is sent even so")
         node = self.nodes[0]
@@ -85,7 +87,8 @@ class PackageRelayTest(BitcoinTestFramework):
         assert_equal(node.getpeerinfo()[0]["bytessent_per_msg"]["sendpackages"], 28)
         assert "sendpackages" not in node.getpeerinfo()[0]["bytesrecv_per_msg"]
         assert_equal(peer_no_sendpackages.sendpackages_received, [0])
-        peer_no_sendpackages.peer_disconnect()
+        assert not node.getpeerinfo()[0]["relaytxpackages"]
+        node.disconnect_p2ps()
 
         self.log.info("Test disconnection if sendpackages is sent after version handshake")
         peer_sendpackages_after_verack = node.add_p2p_connection(P2PTxInvStore())

--- a/test/functional/p2p_package_relay.py
+++ b/test/functional/p2p_package_relay.py
@@ -569,6 +569,30 @@ class PackageRelayTest(BitcoinTestFramework):
         peer_requester_unannounced.send_and_ping(getpkgtxns_request)
         peer_requester_unannounced.wait_for_pkgtxns(package_wtxids)
 
+    @cleanup
+    def test_announcements(self):
+        node = self.nodes[0]
+        package_hex, package_txns, package_wtxids = self.create_package()
+        # The filter should be applied to base fee.
+        node.prioritisetransaction(package_txns[1].rehash(), 0, COIN)
+        assert_equal(len(package_txns), 3)
+        peer_package_relay = node.add_p2p_connection(PackageRelayer())
+        assert node.getpeerinfo()[0]["relaytxpackages"]
+        peer_non_package_relay = node.add_p2p_connection(PackageRelayer(send_sendpackages=False))
+        assert not node.getpeerinfo()[1]["relaytxpackages"]
+        peer_package_relay.send_and_ping(msg_feefilter(1000))
+        peer_non_package_relay.send_and_ping(msg_feefilter(1000))
+
+        node.submitpackage(package_hex)
+        self.fastforward(60)
+        self.log.info("Test that node announces transactions above fee filter to package relay peers")
+        peer_package_relay.wait_for_broadcast([package_txns[0].getwtxid(), package_txns[2].getwtxid()])
+        assert int(package_txns[1].getwtxid(), 16) not in peer_package_relay.get_invs()
+        self.log.info("Test that node announces transactions whose parents are above fee filter to non-package relay peers")
+        peer_non_package_relay.wait_for_broadcast([package_txns[0].getwtxid()])
+        assert int(package_txns[1].getwtxid(), 16) not in peer_non_package_relay.get_invs()
+        assert int(package_txns[2].getwtxid(), 16) not in peer_non_package_relay.get_invs()
+
     def run_test(self):
         self.wallet = MiniWallet(self.nodes[0])
         self.generate(self.wallet, 160)
@@ -583,6 +607,7 @@ class PackageRelayTest(BitcoinTestFramework):
         self.test_ancpkginfo_invalid_ancestors()
         self.test_low_fee_caching()
         self.test_pkgtxns()
+        self.test_announcements()
 
 
 if __name__ == '__main__':

--- a/test/functional/p2p_package_relay.py
+++ b/test/functional/p2p_package_relay.py
@@ -2,23 +2,37 @@
 # Copyright (c) 2022 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test package relay messages"""
+"""
+Test package relay messages and net processing logic on a singular node.
+This has its own test because it requires lots of setmocktimeing and that's hard to coordinate
+across multiple nodes.
+"""
 
+from decimal import Decimal
 import time
 
 from test_framework.messages import (
     CInv,
     MSG_ANCPKGINFO,
+    MSG_TX,
+    MSG_WITNESS_TX,
     MSG_WTX,
     msg_ancpkginfo,
+    msg_feefilter,
     msg_getdata,
+    msg_inv,
+    msg_notfound,
     msg_sendpackages,
+    msg_tx,
     msg_verack,
     msg_wtxidrelay,
 )
 from test_framework.p2p import (
+    NONPREF_PEER_TX_DELAY,
+    ORPHAN_ANCESTOR_GETDATA_INTERVAL,
     p2p_lock,
     P2PTxInvStore,
+    TXID_RELAY_DELAY,
     UNCONDITIONAL_RELAY_DELAY,
 )
 from test_framework.test_framework import BitcoinTestFramework
@@ -52,6 +66,7 @@ class PackageRelayer(P2PTxInvStore):
         self._send_wtxidrelay = send_wtxidrelay
         self._ancpkginfo_received = []
         self._tx_received = []
+        self._getdata_received = []
 
     @property
     def sendpackages_received(self):
@@ -67,6 +82,11 @@ class PackageRelayer(P2PTxInvStore):
     def tx_received(self):
         with p2p_lock:
             return self._tx_received
+
+    @property
+    def getdata_received(self):
+        with p2p_lock:
+            return self._getdata_received
 
     def on_version(self, message):
         if self._send_wtxidrelay:
@@ -84,6 +104,25 @@ class PackageRelayer(P2PTxInvStore):
 
     def on_tx(self, message):
         self._tx_received.append(message)
+
+    def on_getdata(self, message):
+        self._getdata_received.append(message)
+
+    def wait_for_getancpkginfo(self, wtxid16):
+        def test_function():
+            last_getdata = self.last_message.get('getdata')
+            if not last_getdata:
+                return False
+            return last_getdata.inv[0].hash == wtxid16 and last_getdata.inv[0].type == MSG_ANCPKGINFO
+        self.wait_until(test_function, timeout=10)
+
+    def wait_for_getdata_txids(self, txids):
+        def test_function():
+            last_getdata = self.last_message.get('getdata')
+            if not last_getdata:
+                return False
+            return all([item.type == MSG_WITNESS_TX and item.hash in txids for item in last_getdata.inv])
+        self.wait_until(test_function, timeout=10)
 
 class PackageRelayTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -169,7 +208,7 @@ class PackageRelayTest(BitcoinTestFramework):
 
         self.fastforward(UNCONDITIONAL_RELAY_DELAY)
         peer_info_requester.send_and_ping(tx_request)
-        assert_greater_than_or_equal(len(peer_info_requester.tx_received), 1)
+        peer_info_requester.wait_for_tx(package_txns[-1].rehash())
 
         self.log.info("Test that node responds to ancpkginfo request with ancestor package wtxids")
         peer_info_requester.send_and_ping(child_ancpkginfo_request)
@@ -182,12 +221,182 @@ class PackageRelayTest(BitcoinTestFramework):
             peer_info_requester.send_and_ping(parent_ancpkginfo_request)
             assert_equal([int(package_wtxids[i], 16)], peer_info_requester.ancpkginfo_received.pop())
 
+    @cleanup
+    def test_orphan_get_ancpkginfo(self):
+        self.log.info("Test that nodes deal with orphans by requesting ancestor package info")
+        node = self.nodes[0]
+        package_hex, package_txns, package_wtxids = self.create_package()
+        orphan_tx = package_txns[-1]
+        orphan_wtxid = package_wtxids[-1]
+
+        peer_package_relayer = node.add_p2p_connection(PackageRelayer())
+        orphan_inv = CInv(t=MSG_WTX, h=int(orphan_wtxid, 16))
+        peer_package_relayer.send_and_ping(msg_inv([orphan_inv]))
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer_package_relayer.wait_for_getdata([int(orphan_wtxid, 16)])
+        peer_package_relayer.send_and_ping(msg_tx(orphan_tx))
+
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer_package_relayer.sync_with_ping()
+        peer_package_relayer.wait_for_getancpkginfo(int(orphan_wtxid, 16))
+        peer_package_relayer.send_and_ping(msg_ancpkginfo([int(wtxid, 16) for wtxid in package_wtxids]))
+        self.wait_until(lambda: "ancpkginfo" in node.getpeerinfo()[0]["bytesrecv_per_msg"])
+
+    @cleanup
+    def test_orphan_handling_prefer_outbound(self):
+        self.log.info("Test that the node uses all announcers as potential candidates for orphan handling")
+        node = self.nodes[0]
+        package_hex, package_txns, package_wtxids = self.create_package()
+        orphan_tx = package_txns[-1]
+        orphan_wtxid = package_wtxids[-1]
+        orphan_inv = CInv(t=MSG_WTX, h=int(orphan_wtxid, 16))
+
+        peer_inbound = node.add_p2p_connection(PackageRelayer())
+        peer_outbound = node.add_outbound_p2p_connection(PackageRelayer(), p2p_idx=1)
+
+        peer_inbound.send_and_ping(msg_inv([orphan_inv]))
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer_inbound.wait_for_getdata([int(orphan_wtxid, 16)])
+        # Both send invs for the orphan, so the node an expect both to know its ancestors.
+        peer_outbound.send_and_ping(msg_inv([orphan_inv]))
+        peer_inbound.send_and_ping(msg_tx(orphan_tx))
+        self.fastforward(NONPREF_PEER_TX_DELAY)
+
+        self.log.info("Test that the node prefers requesting ancpkginfo from outbound peers")
+        # The outbound peer should be preferred for getting ancpkginfo
+        peer_outbound.wait_for_getancpkginfo(int(orphan_wtxid, 16))
+        # There should be no request to the inbound peer
+        ancpkginfo_request = peer_outbound.getdata_received.pop()
+        assert ancpkginfo_request not in peer_inbound.getdata_received
+
+        self.log.info("Test that, if the preferred peer doesn't respond, the node sends another request")
+        self.fastforward(ORPHAN_ANCESTOR_GETDATA_INTERVAL)
+        peer_inbound.sync_with_ping()
+        peer_inbound.wait_for_getancpkginfo(int(orphan_wtxid, 16))
+
+    @cleanup
+    def test_orphan_handling_prefer_ancpkginfo(self):
+        node = self.nodes[0]
+        package_hex, package_txns, package_wtxids = self.create_package()
+        orphan_tx = package_txns[-1]
+        orphan_wtxid = package_wtxids[-1]
+        orphan_inv = CInv(t=MSG_WTX, h=int(orphan_wtxid, 16))
+
+        peer_nonpackage = node.add_p2p_connection(PackageRelayer(send_sendpackages=False))
+        assert not node.getpeerinfo()[0]["relaytxpackages"]
+        peer_package_relay = node.add_p2p_connection(PackageRelayer())
+
+        peer_nonpackage.send_and_ping(msg_inv([orphan_inv]))
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer_nonpackage.wait_for_getdata([int(orphan_wtxid, 16)])
+        # Both send invs for the orphan, so the node an expect both to know its ancestors.
+        peer_package_relay.send_and_ping(msg_inv([orphan_inv]))
+        peer_nonpackage.send_and_ping(msg_tx(orphan_tx))
+
+        # tx is an orphan. Node should first try to resolve it by requesting ancpkginfo from package relay peer.
+        nonpackage_prev_getdata = len(peer_nonpackage.getdata_received)
+        self.fastforward(NONPREF_PEER_TX_DELAY)
+        peer_nonpackage.sync_with_ping()
+        peer_package_relay.sync_with_ping()
+        self.log.info("Test that the node prefers resolving orphans using package relay peers")
+        peer_package_relay.wait_for_getancpkginfo(int(orphan_wtxid, 16))
+        # The non-package relay peer should not have received any request.
+        assert_equal(nonpackage_prev_getdata, len(peer_nonpackage.getdata_received))
+
+        self.log.info("Test that, if the package relay peer doesn't respond, node falls back to parent txids")
+        self.fastforward(ORPHAN_ANCESTOR_GETDATA_INTERVAL)
+        peer_nonpackage.wait_for_getdata_txids([int(tx.rehash(), 16) for tx in package_txns[:-1]])
+
+    @cleanup
+    def test_orphan_announcer_memory(self):
+        self.log.info("Test that the node remembers who announced orphan transactions")
+        node = self.nodes[0]
+        package_hex, package_txns, package_wtxids = self.create_package()
+        orphan_tx = package_txns[-1]
+        orphan_wtxid = package_wtxids[-1]
+        orphan_inv = CInv(t=MSG_WTX, h=int(orphan_wtxid, 16))
+
+        # Original announcer of orphan
+        peer_package_relay1 = node.add_outbound_p2p_connection(PackageRelayer(), p2p_idx=2)
+        # Sends an inv for the orphan before the node requests orphan tx data.
+        # Preferred for orphan handling over peer3 because it's an outbound connection.
+        peer_package_relay2 = node.add_p2p_connection(PackageRelayer())
+        # Sends an inv for the orphan while the node is requesting ancpkginfo
+        peer_package_relay3 = node.add_p2p_connection(PackageRelayer())
+
+        peer_package_relay1.send_and_ping(msg_inv([orphan_inv]))
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer_package_relay1.wait_for_getdata([int(orphan_wtxid, 16)])
+
+        # Both send invs for the orphan, so the node an expect both to know its ancestors.
+        peer_package_relay2.send_and_ping(msg_inv([orphan_inv]))
+        peer_package_relay1.send_and_ping(msg_tx(orphan_tx))
+
+        peer2_prev_getdata = len(peer_package_relay2.getdata_received)
+        peer3_prev_getdata = len(peer_package_relay3.getdata_received)
+        self.fastforward(NONPREF_PEER_TX_DELAY)
+        peer_package_relay1.wait_for_getancpkginfo(int(orphan_wtxid, 16))
+        peer_package_relay3.send_and_ping(msg_inv([orphan_inv]))
+        # Peers 2 and 3 should not have received any getdata
+        # Not for tx data of the orphan, not for ancpkginfo, and not for parent txids
+        assert_equal(peer2_prev_getdata, len(peer_package_relay2.getdata_received))
+        assert_equal(peer3_prev_getdata, len(peer_package_relay3.getdata_received))
+
+        self.log.info("Test that the node requests ancpkginfo from a different peer upon receiving notfound")
+        orphan_ancpkginfo_notfound = msg_notfound(vec=[CInv(MSG_ANCPKGINFO, int(orphan_wtxid, 16))])
+        peer_package_relay1.send_and_ping(orphan_ancpkginfo_notfound)
+        self.fastforward(1)
+        # Node should try again from peer2
+        peer_package_relay2.wait_for_getancpkginfo(int(orphan_wtxid, 16))
+
+        self.log.info("Test that the node requests ancpkginfo from a different peer if peer disconnects")
+        # Peer 2 disconnected before responding
+        peer_package_relay2.peer_disconnect()
+        self.fastforward(1)
+        peer_package_relay3.sync_with_ping()
+        peer_package_relay3.wait_for_getancpkginfo(int(orphan_wtxid, 16))
+
+    @cleanup
+    def test_ancpkginfo_received(self):
+        node = self.nodes[0]
+        parent1 = self.wallet.create_self_transfer()
+        parent2 = self.wallet.create_self_transfer()
+        child = self.wallet.create_self_transfer_multi(
+            utxos_to_spend=[parent1['new_utxo'], parent2["new_utxo"]],
+            num_outputs=1,
+            fee_per_output=int(DEFAULT_FEE * COIN)
+        )
+        package_txns = [parent1["tx"], parent2["tx"], child["tx"]]
+        package_wtxids = [tx.getwtxid() for tx in package_txns]
+        ancpkginfo_message = msg_ancpkginfo([int(wtxid, 16) for wtxid in package_wtxids])
+
+        self.log.info("Test that unsolicited ancpkginfo results in disconnection")
+        peer1 = node.add_p2p_connection(PackageRelayer())
+        peer1.send_message(ancpkginfo_message)
+        peer1.wait_for_disconnect()
+
+        self.log.info("Test that peer uses ancpkginfo to request orphan's ancestors")
+        orphan_inv = CInv(t=MSG_WTX, h=int(package_wtxids[-1], 16))
+        peer2 = node.add_p2p_connection(PackageRelayer())
+        peer2.send_and_ping(msg_inv([orphan_inv]))
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer2.wait_for_getdata([int(package_wtxids[-1], 16)])
+        peer2.send_and_ping(msg_tx(package_txns[-1]))
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer2.wait_for_getancpkginfo(int(package_wtxids[-1], 16))
+        peer2.send_and_ping(ancpkginfo_message)
+
     def run_test(self):
         self.wallet = MiniWallet(self.nodes[0])
         self.generate(self.wallet, 160)
 
         self.test_sendpackages()
         self.test_ancpkginfo_requests()
+        self.test_orphan_get_ancpkginfo()
+        self.test_orphan_handling_prefer_outbound()
+        self.test_orphan_handling_prefer_ancpkginfo()
+        self.test_orphan_announcer_memory()
+        self.test_ancpkginfo_received()
 
 
 if __name__ == '__main__':

--- a/test/functional/p2p_package_relay.py
+++ b/test/functional/p2p_package_relay.py
@@ -135,6 +135,14 @@ class PackageRelayer(P2PTxInvStore):
             return all([item.type == MSG_WITNESS_TX and item.hash in txids for item in last_getdata.inv])
         self.wait_until(test_function, timeout=10)
 
+    def wait_for_getpkgtxns(self, wtxids):
+        def test_function():
+            last_getpkgtxns = self.last_message.get('getpkgtxns')
+            if not last_getpkgtxns:
+                return False
+            return last_getpkgtxns.hashes == wtxids
+        self.wait_until(test_function, timeout=10)
+
     def wait_for_pkgtxns(self, wtxids):
         def test_function():
             last_pkgtxns = self.last_message.get('pkgtxns')
@@ -414,6 +422,96 @@ class PackageRelayTest(BitcoinTestFramework):
         self.fastforward(NONPREF_PEER_TX_DELAY + 1)
         peer2.wait_for_getancpkginfo(int(package_wtxids[-1], 16))
         peer2.send_and_ping(ancpkginfo_message)
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        # The orphan should not be re-requested.
+        peer2.wait_for_getpkgtxns([int(wtxid, 16) for wtxid in package_wtxids[:-1]])
+
+    @cleanup
+    def test_ancpkginfo_invalid_ancestors(self):
+        node = self.nodes[0]
+        self.log.info("Test that peer does not request tx data if ancpkginfo indicates they won't pass")
+        # Nonstandard due to stuffed op_return
+        grandparent_nonstandard = self.wallet.create_self_transfer(target_weight=50000)
+        middle_tx = self.wallet.create_self_transfer(utxo_to_spend=grandparent_nonstandard["new_utxo"])
+        grandchild = self.wallet.create_self_transfer(utxo_to_spend=middle_tx["new_utxo"])
+        grandparent_wtxid = grandparent_nonstandard["tx"].getwtxid()
+        middle_wtxid = middle_tx["tx"].getwtxid()
+        grandchild_wtxid = grandchild["tx"].getwtxid()
+
+        peer_package_relay = node.add_p2p_connection(PackageRelayer())
+        # Relay the grandparent, it should be added to rejection filter
+        peer_package_relay.send_and_ping(msg_inv([CInv(t=MSG_WTX, h=int(grandparent_wtxid, 16))]))
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer_package_relay.wait_for_getdata([int(grandparent_wtxid, 16)])
+        peer_package_relay.send_and_ping(msg_tx(grandparent_nonstandard["tx"]))
+        assert not grandparent_nonstandard["txid"] in node.getrawmempool()
+
+        # Relay the grandchild: ancpkginfo should be requested.
+        peer_package_relay.send_and_ping(msg_inv([CInv(t=MSG_WTX, h=int(grandchild_wtxid, 16))]))
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer_package_relay.wait_for_getdata([int(grandchild_wtxid, 16)])
+        peer_package_relay.send_and_ping(msg_tx(grandchild["tx"]))
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer_package_relay.wait_for_getancpkginfo(int(grandchild["tx"].getwtxid(), 16))
+        ancpkginfo = msg_ancpkginfo([int(wtxid, 16) for wtxid in [grandparent_wtxid, middle_wtxid, grandchild_wtxid]])
+        # Once received, txdata should not be requested because the grandparent is in recent rejects.
+        peer_package_relay.send_and_ping(ancpkginfo)
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        assert "getpkgtxns" not in peer_package_relay.last_message
+
+        # Relay the parent: ancpkginfo should be requested (only grandparent wtxid was cached).
+        peer_package_relay.send_and_ping(msg_inv([CInv(t=MSG_WTX, h=int(middle_wtxid, 16))]))
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer_package_relay.wait_for_getdata([int(middle_wtxid, 16)])
+        peer_package_relay.getdata_received.clear()
+        peer_package_relay.send_and_ping(msg_tx(middle_tx["tx"]))
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer_package_relay.wait_for_getancpkginfo(int(middle_wtxid, 16))
+
+        self.log.info("Test that failure cache resets after chain tip changes")
+        # After chain tip changes, all transactions can be reconsidered. For example, the
+        # nonstandard grandparent could have been included in the last block.
+        self.generate(node, 1)
+        peer_package_relay.send_and_ping(msg_inv([CInv(t=MSG_WTX, h=int(middle_wtxid, 16))]))
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer_package_relay.wait_for_getdata([int(middle_wtxid, 16)])
+        peer_package_relay.send_and_ping(msg_tx(middle_tx["tx"]))
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer_package_relay.wait_for_getancpkginfo(int(middle_wtxid, 16))
+
+    def test_low_fee_caching(self):
+        node = self.nodes[0]
+        peer_package_relay = node.add_p2p_connection(PackageRelayer())
+        self.log.info("Test that low fee failures are cached but eligible for reconsideration in packages")
+        # If an ancestor has failed but is eligible for reconsideration (i.e. too low fee), the peer
+        # should request txdata.
+        parent_low_fee = self.wallet.create_self_transfer(fee=0, fee_rate=0)
+        node.prioritisetransaction(parent_low_fee["txid"], 0, -1)
+        child = self.wallet.create_self_transfer(utxo_to_spend=parent_low_fee["new_utxo"])
+        parent_wtxid = parent_low_fee["tx"].getwtxid()
+        child_wtxid = child["tx"].getwtxid()
+        peer_package_relay.send_and_ping(msg_inv([CInv(t=MSG_WTX, h=int(parent_wtxid, 16))]))
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer_package_relay.wait_for_getdata([int(parent_wtxid, 16)])
+        peer_package_relay.send_and_ping(msg_tx(parent_low_fee["tx"]))
+        assert not parent_low_fee["txid"] in node.getrawmempool()
+        # The low fee tx should not be downloaded again
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        prev_getdata = len(peer_package_relay.getdata_received)
+        peer_package_relay.send_and_ping(msg_inv([CInv(t=MSG_WTX, h=int(parent_wtxid, 16))]))
+        assert_equal(len(peer_package_relay.getdata_received), prev_getdata)
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        # But it should be downloaded if part of a package, in this case as child's ancestor
+        peer_package_relay.send_and_ping(msg_inv([CInv(t=MSG_WTX, h=int(child_wtxid, 16))]))
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer_package_relay.wait_for_getdata([int(child_wtxid, 16)])
+        peer_package_relay.send_and_ping(msg_tx(child["tx"]))
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer_package_relay.wait_for_getancpkginfo(int(child_wtxid, 16))
+        peer_package_relay.send_and_ping(msg_ancpkginfo([int(parent_wtxid, 16), int(child_wtxid, 16)]))
+        # The tx data should be requested even though the node has seen it before.
+        self.fastforward(NONPREF_PEER_TX_DELAY + 1)
+        peer_package_relay.wait_for_getpkgtxns([int(parent_wtxid, 16)])
 
     @cleanup
     def test_pkgtxns(self):
@@ -467,6 +565,8 @@ class PackageRelayTest(BitcoinTestFramework):
         self.test_orphan_handling_prefer_ancpkginfo()
         self.test_orphan_announcer_memory()
         self.test_ancpkginfo_received()
+        self.test_ancpkginfo_invalid_ancestors()
+        self.test_low_fee_caching()
         self.test_pkgtxns()
 
 

--- a/test/functional/p2p_package_relay.py
+++ b/test/functional/p2p_package_relay.py
@@ -7,6 +7,11 @@
 import time
 
 from test_framework.messages import (
+    CInv,
+    MSG_ANCPKGINFO,
+    MSG_WTX,
+    msg_ancpkginfo,
+    msg_getdata,
     msg_sendpackages,
     msg_verack,
     msg_wtxidrelay,
@@ -14,10 +19,17 @@ from test_framework.messages import (
 from test_framework.p2p import (
     p2p_lock,
     P2PTxInvStore,
+    UNCONDITIONAL_RELAY_DELAY,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_greater_than_or_equal,
+)
+from test_framework.wallet import (
+    COIN,
+    DEFAULT_FEE,
+    MiniWallet,
 )
 
 def cleanup(func):
@@ -28,7 +40,7 @@ def cleanup(func):
             # Clear mempool
             self.generate(self.nodes[0], 1)
             self.nodes[0].disconnect_p2ps()
-            self.nodes[0].setmocktime(int(time.time()))
+            self.nodes[0].setmocktime(self.starttime)
     return wrapper
 
 class PackageRelayer(P2PTxInvStore):
@@ -38,11 +50,23 @@ class PackageRelayer(P2PTxInvStore):
         self._sendpackages_received = []
         self._send_sendpackages = send_sendpackages
         self._send_wtxidrelay = send_wtxidrelay
+        self._ancpkginfo_received = []
+        self._tx_received = []
 
     @property
     def sendpackages_received(self):
         with p2p_lock:
             return self._sendpackages_received
+
+    @property
+    def ancpkginfo_received(self):
+        with p2p_lock:
+            return self._ancpkginfo_received
+
+    @property
+    def tx_received(self):
+        with p2p_lock:
+            return self._tx_received
 
     def on_version(self, message):
         if self._send_wtxidrelay:
@@ -55,10 +79,42 @@ class PackageRelayer(P2PTxInvStore):
     def on_sendpackages(self, message):
         self._sendpackages_received.append(message.version)
 
+    def on_ancpkginfo(self, message):
+        self._ancpkginfo_received.append(message.wtxids)
+
+    def on_tx(self, message):
+        self._tx_received.append(message)
+
 class PackageRelayTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.extra_args = [["-packagerelay=1"]]
+        self.starttime = int(time.time())
+        self.mocktime = self.starttime
+
+    def create_package(self, cpfp=True):
+        """Create package with these transactions:
+        - Parent 1: fee=default
+        - Parent 2: fee=0 if cpfp, else default
+        - Child:    fee=high
+        """
+        parent1 = self.wallet.create_self_transfer()
+        parent2 = self.wallet.create_self_transfer(fee_rate=0, fee=0) if cpfp else self.wallet.create_self_transfer()
+        child = self.wallet.create_self_transfer_multi(
+            utxos_to_spend=[parent1['new_utxo'], parent2["new_utxo"]],
+            num_outputs=1,
+            fee_per_output=int(DEFAULT_FEE * COIN)
+        )
+        package_hex = [parent1["hex"], parent2["hex"], child["hex"]]
+        package_txns = [parent1["tx"], parent2["tx"], child["tx"]]
+        package_wtxids = [tx.getwtxid() for tx in package_txns]
+        return package_hex, package_txns, package_wtxids
+
+    def fastforward(self, seconds):
+        """Convenience helper function to fast-forward, so we don't need to keep track of the
+        starting time when we call setmocktime."""
+        self.mocktime += seconds
+        self.nodes[0].setmocktime(self.mocktime)
 
     @cleanup
     def test_sendpackages(self):
@@ -95,8 +151,44 @@ class PackageRelayTest(BitcoinTestFramework):
         peer_sendpackages_after_verack.send_message(msg_sendpackages())
         peer_sendpackages_after_verack.wait_for_disconnect()
 
+    @cleanup
+    def test_ancpkginfo_requests(self):
+        node = self.nodes[0]
+        peer_info_requester = node.add_p2p_connection(PackageRelayer())
+        package_hex, package_txns, package_wtxids = self.create_package(cpfp=False)
+        node.submitpackage(package_hex)
+        assert_equal(node.getmempoolentry(package_txns[-1].rehash())["ancestorcount"], 3)
+
+        self.log.info("Test that ancpkginfo requests for unannounced transactions are ignored until UNCONDITIONAL_RELAY_DELAY elapses")
+        tx_request = msg_getdata([CInv(t=MSG_WTX, h=int(package_wtxids[-1], 16))])
+        peer_info_requester.send_and_ping(tx_request)
+        assert not peer_info_requester.tx_received
+        child_ancpkginfo_request = msg_getdata([CInv(t=MSG_ANCPKGINFO, h=int(package_wtxids[-1], 16))])
+        peer_info_requester.send_and_ping(child_ancpkginfo_request)
+        assert not peer_info_requester.ancpkginfo_received
+
+        self.fastforward(UNCONDITIONAL_RELAY_DELAY)
+        peer_info_requester.send_and_ping(tx_request)
+        assert_greater_than_or_equal(len(peer_info_requester.tx_received), 1)
+
+        self.log.info("Test that node responds to ancpkginfo request with ancestor package wtxids")
+        peer_info_requester.send_and_ping(child_ancpkginfo_request)
+        assert_greater_than_or_equal(len(peer_info_requester.ancpkginfo_received), 1)
+        last_ancpkginfo_received = peer_info_requester.ancpkginfo_received.pop()
+        assert all([int(wtxid, 16) in last_ancpkginfo_received for wtxid in package_wtxids])
+        # When a tx has no unconfirmed ancestors, ancpkginfo just contains its own wtxid
+        for i in range(len(package_txns) - 1):
+            parent_ancpkginfo_request = msg_getdata([CInv(t=MSG_ANCPKGINFO, h=int(package_wtxids[i], 16))])
+            peer_info_requester.send_and_ping(parent_ancpkginfo_request)
+            assert_equal([int(package_wtxids[i], 16)], peer_info_requester.ancpkginfo_received.pop())
+
     def run_test(self):
+        self.wallet = MiniWallet(self.nodes[0])
+        self.generate(self.wallet, 160)
+
         self.test_sendpackages()
+        self.test_ancpkginfo_requests()
+
 
 if __name__ == '__main__':
     PackageRelayTest().main()

--- a/test/functional/p2p_package_relay.py
+++ b/test/functional/p2p_package_relay.py
@@ -360,6 +360,8 @@ class PackageRelayTest(BitcoinTestFramework):
         peer_package_relay2 = node.add_p2p_connection(PackageRelayer())
         # Sends an inv for the orphan while the node is requesting ancpkginfo
         peer_package_relay3 = node.add_p2p_connection(PackageRelayer())
+        # Sends an inv for the orphan while the node is requesting txdata using the ancpkginfo
+        peer_package_relay4 = node.add_p2p_connection(PackageRelayer())
 
         peer_package_relay1.send_and_ping(msg_inv([orphan_inv]))
         self.fastforward(NONPREF_PEER_TX_DELAY + 1)
@@ -387,11 +389,21 @@ class PackageRelayTest(BitcoinTestFramework):
         peer_package_relay2.wait_for_getancpkginfo(int(orphan_wtxid, 16))
 
         self.log.info("Test that the node requests ancpkginfo from a different peer if peer disconnects")
-        # Peer 2 disconnected before responding
+        # Peer2 disconnected before responding
         peer_package_relay2.peer_disconnect()
         self.fastforward(1)
         peer_package_relay3.sync_with_ping()
         peer_package_relay3.wait_for_getancpkginfo(int(orphan_wtxid, 16))
+        # Peer3 provides ancpkginfo but doesn't respond to getpkgtxns request
+        ancpkginfo_message = msg_ancpkginfo([int(wtxid, 16) for wtxid in package_wtxids])
+        peer_package_relay3.send_and_ping(ancpkginfo_message)
+        self.fastforward(1)
+        peer_package_relay3.wait_for_getpkgtxns([int(wtxid, 16) for wtxid in package_wtxids[:-1]])
+        peer_package_relay4.send_and_ping(msg_inv([orphan_inv]))
+        # The getpkgtxns request to peer3 expires after 60sec.
+        self.fastforward(60)
+        peer_package_relay3.sync_with_ping()
+        peer_package_relay4.wait_for_getancpkginfo(int(orphan_wtxid, 16))
 
     @cleanup
     def test_ancpkginfo_received(self):
@@ -425,6 +437,9 @@ class PackageRelayTest(BitcoinTestFramework):
         self.fastforward(NONPREF_PEER_TX_DELAY + 1)
         # The orphan should not be re-requested.
         peer2.wait_for_getpkgtxns([int(wtxid, 16) for wtxid in package_wtxids[:-1]])
+        peer2.send_and_ping(msg_pkgtxns(txns=package_txns[:-1]))
+        peer2.sync_with_ping()
+        assert_equal(set(node.getrawmempool()), set([tx.rehash() for tx in package_txns]))
 
     @cleanup
     def test_ancpkginfo_invalid_ancestors(self):

--- a/test/functional/p2p_package_relay_network.py
+++ b/test/functional/p2p_package_relay_network.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Test that package works successfully in a "network" of nodes. Send various packages from different
+nodes on a network in which some nodes have already received some of the transactions (and submitted
+them to mempool, kept them as orphans or rejected them as too-low-feerate transactions). The
+packages should be received and accepted by all transactions on the network.
+"""
+
+from decimal import Decimal
+from test_framework.messages import (
+    CInv,
+    MSG_WTX,
+    msg_inv,
+    msg_tx,
+)
+from test_framework.p2p import (
+    P2PInterface,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than_or_equal,
+    assert_greater_than,
+    create_lots_of_big_transactions,
+    gen_return_txouts,
+    try_rpc,
+)
+from test_framework.wallet import (
+    COIN,
+    DEFAULT_FEE,
+    MiniWallet,
+)
+
+FEERATE_1SAT_VB = Decimal("0.00001")
+
+class PackageRelayTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 5
+        self.extra_args = [["-packagerelay=1", "-datacarriersize=100000", "-maxmempool=5"]] * self.num_nodes
+
+    def create_packages(self):
+        # Basic 1-parent-1-child package
+        low_fee_parent = self.wallet.create_self_transfer(fee_rate=FEERATE_1SAT_VB)
+        child = self.wallet.create_self_transfer(utxo_to_spend=low_fee_parent["new_utxo"], fee_rate=10*FEERATE_1SAT_VB)
+        package_hex = [low_fee_parent["hex"], child["hex"]]
+        self.packages_to_submit.append(package_hex)
+        self.transactions_to_presend[0] = [low_fee_parent["tx"]]
+        self.transactions_to_presend[4] = [child["tx"]]
+        self.total_txns += 2
+
+        # Diamond shape: 1 grandparent, 2 parents, 1 child
+        diamond_grandparent = self.wallet.create_self_transfer_multi(num_outputs=2, fee_per_output=COIN)
+        diamond_parent1 = self.wallet.create_self_transfer(utxo_to_spend=diamond_grandparent["new_utxos"][0], fee_rate=10*FEERATE_1SAT_VB)
+        diamond_parent2 = self.wallet.create_self_transfer(utxo_to_spend=diamond_grandparent["new_utxos"][1], fee_rate=FEERATE_1SAT_VB)
+        diamond_child = self.wallet.create_self_transfer_multi(utxos_to_spend=[diamond_parent1["new_utxo"], diamond_parent2["new_utxo"]], fee_per_output=COIN)
+        self.packages_to_submit.append([diamond_grandparent["hex"], diamond_parent1["hex"], diamond_parent2["hex"], diamond_child["hex"]])
+        self.nodes[0].prioritisetransaction(diamond_grandparent["txid"], 0, COIN)
+        self.transactions_to_presend[0] += [diamond_grandparent["tx"]]
+        self.total_txns += 4
+
+        # Two 1-parent-1-child packages with overlapping ancestors
+        low_fee_parent_2c = self.wallet.create_self_transfer_multi(num_outputs=2, fee_per_output=200)
+        child1 = self.wallet.create_self_transfer(utxo_to_spend=low_fee_parent_2c["new_utxos"][0])
+        child2 = self.wallet.create_self_transfer(utxo_to_spend=low_fee_parent_2c["new_utxos"][1])
+        self.packages_to_submit.append([low_fee_parent_2c["hex"], child1["hex"]])
+        self.packages_to_submit.append([low_fee_parent_2c["hex"], child2["hex"]])
+        self.transactions_to_presend[1] = [child1["tx"]]
+        self.total_txns += 3
+
+        # 3 generation parent + child + grandchild
+        normal_parent = self.wallet.create_self_transfer()
+        normal_child = self.wallet.create_self_transfer(utxo_to_spend=normal_parent["new_utxo"])
+        normal_grandchild = self.wallet.create_self_transfer(utxo_to_spend=normal_child["new_utxo"], fee_rate=10*FEERATE_1SAT_VB)
+        self.packages_to_submit.append([normal_parent["hex"], normal_child["hex"], normal_grandchild["hex"]])
+        self.transactions_to_presend[2] = [normal_parent["tx"]]
+        self.transactions_to_presend[3] = [normal_child["tx"]]
+        self.total_txns += 3
+
+        # 3 generation parent(0fee) + child(0fee) + grandchild
+        parent_0 = self.wallet.create_self_transfer(fee_rate=FEERATE_1SAT_VB)
+        child_0 = self.wallet.create_self_transfer(utxo_to_spend=parent_0["new_utxo"], fee_rate=FEERATE_1SAT_VB)
+        grandchild_bumper = self.wallet.create_self_transfer(utxo_to_spend=child_0["new_utxo"], fee_rate=20*FEERATE_1SAT_VB)
+        self.packages_to_submit.append([parent_0["hex"], child_0["hex"], grandchild_bumper["hex"]])
+        self.transactions_to_presend[0] += [parent_0["tx"]]
+        self.transactions_to_presend[1] += [child_0["tx"]]
+        self.transactions_to_presend[2] += [child_0["tx"]]
+        self.transactions_to_presend[3] += [grandchild_bumper["tx"]]
+        self.total_txns += 3
+
+    def run_test(self):
+        self.ctr = 0
+        filler_wallet = MiniWallet(self.nodes[0])
+        self.wallet = MiniWallet(self.nodes[1])
+        self.generate(self.wallet, 50)
+        self.generate(filler_wallet, 75)
+        self.generate(self.wallet, 100)
+
+        self.packages_to_submit = []
+        self.transactions_to_presend = [[]] * self.num_nodes
+        self.total_txns = 0
+
+        self.log.info("Fill mempools with large transactions to raise mempool minimum feerates")
+        txouts = gen_return_txouts()
+        approx_vsize = sum([len(txout.serialize()) for txout in txouts]) + 40
+        mempool_filler_transactions = []
+        filler_wallet.rescan_utxos(include_mempool=True)
+        for i in range(2, 76):
+            fee = FEERATE_1SAT_VB / 1000 * approx_vsize * i
+            mempool_filler_transactions.extend(create_lots_of_big_transactions(filler_wallet, self.nodes[0], fee, 1, txouts)[1])
+        for node in self.nodes[1:]:
+            for txhex in mempool_filler_transactions:
+                node.sendrawtransaction(txhex)
+        self.sync_mempools()
+        for node in self.nodes:
+            assert_equal(node.getmempoolinfo()['minrelaytxfee'], FEERATE_1SAT_VB)
+            assert_greater_than(node.getmempoolinfo()['mempoolminfee'], FEERATE_1SAT_VB)
+
+        self.log.info("Create transactions and then mature the coinbases")
+        self.wallet.rescan_utxos(include_mempool=True)
+        self.create_packages()
+
+        self.peers = []
+        for i in range(self.num_nodes):
+            # Add outbound connections for faster relay
+            self.peers.append(self.nodes[i].add_outbound_p2p_connection(P2PInterface(), p2p_idx=i, connection_type="outbound-full-relay"))
+
+        self.log.info("Pre-send some transactions to nodes")
+        for i in range(self.num_nodes):
+            peer = self.peers[i]
+            for tx in self.transactions_to_presend[i]:
+                inv = CInv(t=MSG_WTX, h=int(tx.getwtxid(), 16))
+                peer.send_and_ping(msg_inv([inv]))
+                peer.wait_for_getdata([int(tx.getwtxid(), 16)])
+                peer.send_and_ping(msg_tx(tx))
+
+        self.log.info("Submit full packages to their respective nodes")
+        for i, package_hex in enumerate(self.packages_to_submit):
+            self.nodes[i % self.num_nodes].submitpackage(package_hex)
+
+        self.log.info("Wait for mempools to sync (this is currently broken)")
+        # self.sync_mempools(timeout=90)
+
+
+if __name__ == '__main__':
+    PackageRelayTest().main()

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -2064,7 +2064,7 @@ class SegWitTest(BitcoinTestFramework):
         test_transaction_acceptance(self.nodes[0], self.wtx_node, tx2, with_witness=True, accepted=False)
 
         # Expect a request for parent (tx) by txid despite use of WTX peer
-        self.wtx_node.wait_for_getdata([tx.sha256], 60)
+        self.wtx_node.wait_for_getdata([tx.sha256], 65)
         with p2p_lock:
             lgd = self.wtx_node.lastgetdata[:]
         assert_equal(lgd, [CInv(MSG_WITNESS_TX, tx.sha256)])

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -129,6 +129,7 @@ class NetTest(BitcoinTestFramework):
                 "id": no_version_peer_id,
                 "inbound": True,
                 "inflight": [],
+                "relaytxpackages" : False,
                 "last_block": 0,
                 "last_transaction": 0,
                 "lastrecv": 0,

--- a/test/functional/rpc_packages.py
+++ b/test/functional/rpc_packages.py
@@ -20,7 +20,6 @@ from test_framework.util import (
     assert_raises_rpc_error,
 )
 from test_framework.wallet import (
-    COIN,
     DEFAULT_FEE,
     MiniWallet,
 )
@@ -325,42 +324,6 @@ class RPCPackagesTest(BitcoinTestFramework):
         peer.wait_for_broadcast([tx["tx"].getwtxid() for tx in package_txns])
         self.generate(node, 1)
 
-    def test_submit_cpfp(self):
-        node = self.nodes[0]
-        peer = node.add_p2p_connection(P2PTxInvStore())
-
-        # Package with 2 parents and 1 child. One parent pays for itself using modified fees, and
-        # another has 0 fees but is bumped by child.
-        tx_poor = self.wallet.create_self_transfer(fee=0, fee_rate=0)
-        tx_rich = self.wallet.create_self_transfer(fee=0, fee_rate=0)
-        node.prioritisetransaction(tx_rich["txid"], 0, int(DEFAULT_FEE * COIN))
-        package_txns = [tx_rich, tx_poor]
-        coins = [tx["new_utxo"] for tx in package_txns]
-        tx_child = self.wallet.create_self_transfer_multi(utxos_to_spend=coins, fee_per_output=10000) #DEFAULT_FEE
-        package_txns.append(tx_child)
-
-        submitpackage_result = node.submitpackage([tx["hex"] for tx in package_txns])
-
-        rich_parent_result = submitpackage_result["tx-results"][tx_rich["wtxid"]]
-        poor_parent_result = submitpackage_result["tx-results"][tx_poor["wtxid"]]
-        child_result = submitpackage_result["tx-results"][tx_child["tx"].getwtxid()]
-        assert_equal(rich_parent_result["fees"]["base"], 0)
-        assert_equal(poor_parent_result["fees"]["base"], 0)
-        assert_equal(child_result["fees"]["base"], DEFAULT_FEE)
-        # The "rich" parent does not require CPFP so its effective feerate.
-        assert_fee_amount(DEFAULT_FEE, tx_rich["tx"].get_vsize(), rich_parent_result["fees"]["effective-feerate"])
-        assert_equal(rich_parent_result["fees"]["effective-includes"], [tx_rich["wtxid"]])
-        # The "poor" parent and child's effective feerates are the same, composed of the child's fee
-        # divided by their combined vsize.
-        assert_fee_amount(DEFAULT_FEE, tx_poor["tx"].get_vsize() + tx_child["tx"].get_vsize(), poor_parent_result["fees"]["effective-feerate"])
-        assert_fee_amount(DEFAULT_FEE, tx_poor["tx"].get_vsize() + tx_child["tx"].get_vsize(), child_result["fees"]["effective-feerate"])
-        assert_equal([tx_poor["wtxid"], tx_child["tx"].getwtxid()], poor_parent_result["fees"]["effective-includes"])
-        assert_equal([tx_poor["wtxid"], tx_child["tx"].getwtxid()], child_result["fees"]["effective-includes"])
-
-        # The node will broadcast each transaction, still abiding by its peer's fee filter
-        peer.wait_for_broadcast([tx["tx"].getwtxid() for tx in package_txns])
-        self.generate(node, 1)
-
     def test_submitpackage(self):
         node = self.nodes[0]
 
@@ -368,9 +331,6 @@ class RPCPackagesTest(BitcoinTestFramework):
         for num_parents in [1, 2, 24]:
             self.test_submit_child_with_parents(num_parents, False)
             self.test_submit_child_with_parents(num_parents, True)
-
-        self.log.info("Submitpackage valid packages with CPFP")
-        self.test_submit_cpfp()
 
         self.log.info("Submitpackage only allows packages of 1 child with its parents")
         # Chain of 3 transactions has too many generations

--- a/test/functional/rpc_packages.py
+++ b/test/functional/rpc_packages.py
@@ -325,17 +325,10 @@ class RPCPackagesTest(BitcoinTestFramework):
         self.generate(node, 1)
 
     def test_submitpackage(self):
-        node = self.nodes[0]
-
         self.log.info("Submitpackage valid packages with 1 child and some number of parents")
         for num_parents in [1, 2, 24]:
             self.test_submit_child_with_parents(num_parents, False)
             self.test_submit_child_with_parents(num_parents, True)
-
-        self.log.info("Submitpackage only allows packages of 1 child with its parents")
-        # Chain of 3 transactions has too many generations
-        chain_hex = [t["hex"] for t in self.wallet.create_self_transfer_chain(chain_length=25)]
-        assert_raises_rpc_error(-25, "not-child-with-parents", node.submitpackage, chain_hex)
 
 
 if __name__ == "__main__":

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1860,3 +1860,21 @@ class msg_sendtxrcncl:
     def __repr__(self):
         return "msg_sendtxrcncl(version=%lu, salt=%lu)" %\
             (self.version, self.salt)
+
+class msg_sendpackages:
+    __slots__ = ("version")
+    msgtype = b"sendpackages"
+
+    def __init__(self):
+        self.version = 0
+
+    def deserialize(self, f):
+        self.version = struct.unpack("<I", f.read(4))[0]
+
+    def serialize(self):
+        r = b""
+        r += struct.pack("<I", self.version)
+        return r
+
+    def __repr__(self):
+        return "msg_sendpackages(version=%u)".format(self.version)

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -60,6 +60,7 @@ MSG_WTX = 5
 MSG_WITNESS_FLAG = 1 << 30
 MSG_TYPE_MASK = 0xffffffff >> 2
 MSG_WITNESS_TX = MSG_TX | MSG_WITNESS_FLAG
+MSG_ANCPKGINFO = 6
 
 FILTER_TYPE_BASIC = 0
 
@@ -340,6 +341,7 @@ class CInv:
         MSG_FILTERED_BLOCK: "filtered Block",
         MSG_CMPCT_BLOCK: "CompactBlock",
         MSG_WTX: "WTX",
+        MSG_ANCPKGINFO: "ancpkginfo",
     }
 
     def __init__(self, t=0, h=0):
@@ -1878,3 +1880,22 @@ class msg_sendpackages:
 
     def __repr__(self):
         return "msg_sendpackages(version=%u)".format(self.version)
+
+class msg_ancpkginfo:
+    __slots__ = ("wtxids")
+    msgtype = b"ancpkginfo"
+
+    def __init__(self, wtxids=None):
+        self.wtxids = wtxids if wtxids is not None else []
+
+    def deserialize(self, f):
+        self.wtxids = deser_uint256_vector(f)
+
+    def serialize(self):
+        r = b""
+        r += ser_uint256_vector(self.wtxids)
+        return r
+
+    def __repr__(self):
+        return "msg_ancpkginfo(wtxids=%s)" % (self.wtxids)
+

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -61,6 +61,7 @@ MSG_WITNESS_FLAG = 1 << 30
 MSG_TYPE_MASK = 0xffffffff >> 2
 MSG_WITNESS_TX = MSG_TX | MSG_WITNESS_FLAG
 MSG_ANCPKGINFO = 6
+MSG_PKGTXNS = 7
 
 FILTER_TYPE_BASIC = 0
 
@@ -342,6 +343,7 @@ class CInv:
         MSG_CMPCT_BLOCK: "CompactBlock",
         MSG_WTX: "WTX",
         MSG_ANCPKGINFO: "ancpkginfo",
+        MSG_PKGTXNS: "pkgtxns",
     }
 
     def __init__(self, t=0, h=0):
@@ -1899,3 +1901,39 @@ class msg_ancpkginfo:
     def __repr__(self):
         return "msg_ancpkginfo(wtxids=%s)" % (self.wtxids)
 
+class msg_pkgtxns:
+    __slots__ = ("txns")
+    msgtype = b"pkgtxns"
+
+    def __init__(self, txns=None):
+        self.txns = txns if txns is not None else []
+
+    def deserialize(self, f):
+        self.txns = deser_vector(f, CTransaction)
+
+    def serialize(self):
+        r = b""
+        r += ser_vector(self.txns, "serialize_with_witness")
+        return r
+
+    def __repr__(self):
+        return "msg_pkgtxns(txns=%s)" % (self.txns)
+
+
+class msg_getpkgtxns:
+    __slots__ = ("hashes")
+    msgtype = b"getpkgtxns"
+
+    def __init__(self, hashes=None):
+        self.hashes = hashes if hashes is not None else []
+
+    def deserialize(self, f):
+        self.hashes = deser_uint256_vector(f)
+
+    def serialize(self):
+        r = b""
+        r += ser_uint256_vector(self.hashes)
+        return r
+
+    def __repr__(self):
+        return "msg_getpkgtxns(hashes=%s)" % (self.hashes)

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -100,6 +100,11 @@ P2P_VERSION_RELAY = 1
 NONPREF_PEER_TX_DELAY = 2
 # How long a transaction has to be in the mempool before it can unconditionally be relayed, in seconds
 UNCONDITIONAL_RELAY_DELAY = 2 * 60
+# How long to delay requesting transactions via txids, if we have wtxid-relaying peers
+TXID_RELAY_DELAY = 2
+# How long to wait before requesting orphan ancpkginfo/parents from an additional peer.
+ORPHAN_ANCESTOR_GETDATA_INTERVAL = 60
+
 
 MESSAGEMAP = {
     b"addr": msg_addr,

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -54,11 +54,13 @@ from test_framework.messages import (
     msg_getcfilters,
     msg_getdata,
     msg_getheaders,
+    msg_getpkgtxns,
     msg_headers,
     msg_inv,
     msg_mempool,
     msg_merkleblock,
     msg_notfound,
+    msg_pkgtxns,
     msg_ping,
     msg_pong,
     msg_sendaddrv2,
@@ -128,11 +130,13 @@ MESSAGEMAP = {
     b"getcfilters": msg_getcfilters,
     b"getdata": msg_getdata,
     b"getheaders": msg_getheaders,
+    b"getpkgtxns": msg_getpkgtxns,
     b"headers": msg_headers,
     b"inv": msg_inv,
     b"mempool": msg_mempool,
     b"merkleblock": msg_merkleblock,
     b"notfound": msg_notfound,
+    b"pkgtxns": msg_pkgtxns,
     b"ping": msg_ping,
     b"pong": msg_pong,
     b"sendaddrv2": msg_sendaddrv2,
@@ -427,10 +431,12 @@ class P2PInterface(P2PConnection):
     def on_getblocktxn(self, message): pass
     def on_getdata(self, message): pass
     def on_getheaders(self, message): pass
+    def on_getpkgtxns(self, message): pass
     def on_headers(self, message): pass
     def on_mempool(self, message): pass
     def on_merkleblock(self, message): pass
     def on_notfound(self, message): pass
+    def on_pkgtxns(self, message): pass
     def on_pong(self, message): pass
     def on_sendaddrv2(self, message): pass
     def on_sendcmpct(self, message): pass
@@ -789,6 +795,7 @@ class P2PDataStore(P2PInterface):
                 # Check that none of the txs are now in the mempool
                 for tx in txs:
                     assert tx.hash not in raw_mempool, "{} tx found in mempool".format(tx.hash)
+
 
 class P2PTxInvStore(P2PInterface):
     """A P2PInterface which stores a count of how many times each txid has been announced."""

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -33,6 +33,8 @@ from test_framework.messages import (
     MAX_HEADERS_RESULTS,
     msg_addr,
     msg_addrv2,
+    msg_ancpkginfo,
+    MSG_ANCPKGINFO,
     msg_block,
     MSG_BLOCK,
     msg_blocktxn,
@@ -96,10 +98,13 @@ P2P_SUBVERSION = "/python-p2p-tester:0.0.3/"
 P2P_VERSION_RELAY = 1
 # Delay after receiving a tx inv before requesting transactions from non-preferred peers, in seconds
 NONPREF_PEER_TX_DELAY = 2
+# How long a transaction has to be in the mempool before it can unconditionally be relayed, in seconds
+UNCONDITIONAL_RELAY_DELAY = 2 * 60
 
 MESSAGEMAP = {
     b"addr": msg_addr,
     b"addrv2": msg_addrv2,
+    b"ancpkginfo": msg_ancpkginfo,
     b"block": msg_block,
     b"blocktxn": msg_blocktxn,
     b"cfcheckpt": msg_cfcheckpt,

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -62,6 +62,7 @@ from test_framework.messages import (
     msg_sendaddrv2,
     msg_sendcmpct,
     msg_sendheaders,
+    msg_sendpackages,
     msg_sendtxrcncl,
     msg_tx,
     MSG_TX,
@@ -127,6 +128,7 @@ MESSAGEMAP = {
     b"sendaddrv2": msg_sendaddrv2,
     b"sendcmpct": msg_sendcmpct,
     b"sendheaders": msg_sendheaders,
+    b"sendpackages": msg_sendpackages,
     b"sendtxrcncl": msg_sendtxrcncl,
     b"tx": msg_tx,
     b"verack": msg_verack,
@@ -423,6 +425,7 @@ class P2PInterface(P2PConnection):
     def on_sendaddrv2(self, message): pass
     def on_sendcmpct(self, message): pass
     def on_sendheaders(self, message): pass
+    def on_sendpackages(self, message): pass
     def on_sendtxrcncl(self, message): pass
     def on_tx(self, message): pass
     def on_wtxidrelay(self, message): pass

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -505,6 +505,7 @@ def gen_return_txouts():
 # transaction to make it large.  See gen_return_txouts() above.
 def create_lots_of_big_transactions(mini_wallet, node, fee, tx_batch_size, txouts, utxos=None):
     txids = []
+    txhex = []
     use_internal_utxos = utxos is None
     for _ in range(tx_batch_size):
         tx = mini_wallet.create_self_transfer(
@@ -512,10 +513,11 @@ def create_lots_of_big_transactions(mini_wallet, node, fee, tx_batch_size, txout
             fee=fee,
         )["tx"]
         tx.vout.extend(txouts)
+        txhex.append(tx.serialize().hex())
         res = node.testmempoolaccept([tx.serialize().hex()])[0]
         assert_equal(res['fees']['base'], fee)
         txids.append(node.sendrawtransaction(tx.serialize().hex()))
-    return txids
+    return txids, txhex
 
 
 def mine_large_block(test_framework, mini_wallet, node):

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -181,6 +181,7 @@ BASE_SCRIPTS = [
     'wallet_txn_clone.py --segwit',
     'rpc_getchaintips.py',
     'rpc_misc.py',
+    'p2p_package_relay.py',
     'interface_rest.py',
     'mempool_spend_coinbase.py',
     'wallet_avoid_mixing_output_types.py --descriptors',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -182,6 +182,7 @@ BASE_SCRIPTS = [
     'rpc_getchaintips.py',
     'rpc_misc.py',
     'p2p_package_relay.py',
+    'p2p_package_relay_network.py',
     'interface_rest.py',
     'mempool_spend_coinbase.py',
     'wallet_avoid_mixing_output_types.py --descriptors',


### PR DESCRIPTION
Experimental code.

**General structure**
This might be helpful for reviewing. The PR can also be split into sub-PRs like this.

0. Mempool logic to make sure we can handle whatever the peer throws at us (just rebased on here, can work on these in parallel). This PR is open, n26711.

    (**P2P stuff starts at commit 52bf734202c5a6448833edf8efccea10bcb83a03**)

1. Refactoring, create a `TxPackageTracker` module that always exists even if package relay is turned off. It wraps the `TxOrphanage` and forwards calls.

2. Beef up an "orphan resolution module" within `TxPackageTracker`. It keeps track of what orphans we're trying to get parents for (currently still requesting by txid) and tells Peerman what should be downloaded/validated, when. Improve orphan handling by remembering which peers announced the orphan to allow retrying failed requests, requesting from preferred first, accounting for overloaded peers, etc. Tweak the eviction/rate limiting logic so that, even if an inbound is sending lots of orphans, we're still able to resolve orphans with outbounds at 1/2*`INVENTORY_BROADCAST_PER_SECOND` rate (for example).

4. Add a `-packagerelay` option and the "sendpackages" negotiation logic.
Add logic for requesting `MSG_ANCPKGINFO` and serving "ancpkginfo." When resolving orphans, prefer package relay peers and ask for "ancpkginfo" from them.

5. When receiving package info, track which transactions need to be downloaded. At this point, just download and validate individually. Protect stuff that's already in our orphanage from eviction. (Note: in the future, we can add new package info versions, while keeping the `PackageToDownload` data structures generic).
Add "getpkgtxns" and "pkgtxns" logic, and `MSG_PKGTXNS. Download and submit packages.

Todos
- Have `TxPackageTracker` wrap/own `TxOrphanage`
- Protect some quantity of orphans, ensure that we can always get packages relayed from outbounds
- Tweak delays / expiry to make sure 1 peer can't keep stalling to make us forget tx
- Needs unit tests and fuzz for `TxPackageTracker`
- Cache rejections of subpackages

Done but in other branches
- When Loading mempool from disk, ensure packages persist

Additional Maybe Todos
- Look in vExtra for parents/transactions listed in ancpkginfo
- if txn-already-have (recently confirmed), `Exclude()`
-  Add a map of <wtxid, {fees, size}> to `MemPoolAccept` to check ancestor subpackage fees prior to sending to AcceptMultipleTransactions
- fuzz Packageifier
- If orphanage is full, fall back to downloading another time