### PR TITLE
WIP per-peer orphanage limits

### DIFF
--- a/src/bench/CMakeLists.txt
+++ b/src/bench/CMakeLists.txt
@@ -51,6 +51,7 @@ add_executable(bench_bitcoin
   sign_transaction.cpp
   streams_findbyte.cpp
   strencodings.cpp
+  txorphanage.cpp
   util_time.cpp
   verify_script.cpp
   xor.cpp

--- a/src/bench/txorphanage.cpp
+++ b/src/bench/txorphanage.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2011-2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <consensus/amount.h>
+#include <net.h>
+#include <primitives/transaction.h>
+#include <test/util/setup_common.h>
+#include <txorphanage.h>
+#include <util/check.h>
+
+#include <cstdint>
+#include <memory>
+
+
+static void OrphanageEviction(benchmark::Bench& bench)
+{
+    NodeId NUM_PEERS{200};
+    unsigned int NUM_TRANSACTIONS{2000};
+
+    FastRandomContext det_rand{true};
+
+    TxOrphanage orphanage;
+    for (unsigned int i{0}; i < NUM_TRANSACTIONS; ++i) {
+        // Very small transaction
+        CMutableTransaction tx;
+        tx.vin.emplace_back(Txid::FromUint256(det_rand.rand256()), i);
+        tx.vout.resize(1);
+        tx.vout[0].scriptPubKey = CScript();
+        // Each output progressively larger
+        tx.vout[0].nValue = i * CENT;
+        auto ptx{MakeTransactionRef(tx)};
+
+        for (NodeId peer{0}; peer < NUM_PEERS; ++peer) {
+            orphanage.AddTx(ptx, peer);
+        }
+    }
+
+    assert(orphanage.Size() == NUM_TRANSACTIONS);
+
+    bench.run([&]() NO_THREAD_SAFETY_ANALYSIS {
+        orphanage.LimitOrphans(0, det_rand);
+    });
+}
+
+BENCHMARK(OrphanageEviction, benchmark::PriorityLevel::HIGH);

--- a/src/node/txdownloadman.h
+++ b/src/node/txdownloadman.h
@@ -36,6 +36,11 @@ static constexpr auto NONPREF_PEER_TX_DELAY{2s};
 static constexpr auto OVERLOADED_PEER_TX_DELAY{2s};
 /** How long to wait before downloading a transaction from an additional peer */
 static constexpr auto GETDATA_TX_INTERVAL{60s};
+/** Maximum permitted bytes used by transactions in orphanage for a single peer. Equivalent to one
+ * maximally-sized transaction to ensure that each peer can "use" at least 1 orphan slot even in the
+ * presence of spammy peers. */
+static constexpr unsigned int MAX_ORPHAN_BYTES_PER_PEER{MAX_STANDARD_TX_WEIGHT};
+
 struct TxDownloadOptions {
     /** Read-only reference to mempool. */
     const CTxMemPool& m_mempool;

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -195,7 +195,8 @@ bool TxDownloadManagerImpl::AddTxAnnouncement(NodeId peer, const GenTxid& gtxid,
     // - exists in orphanage
     // - peer can be an orphan resolution candidate
     if (gtxid.IsWtxid()) {
-        if (auto orphan_tx{m_orphanage.GetTx(Wtxid::FromUint256(gtxid.GetHash()))}) {
+        const auto wtxid{Wtxid::FromUint256(gtxid.GetHash())};
+        if (auto orphan_tx{m_orphanage.GetTx(wtxid)}) {
             auto unique_parents{GetUniqueParents(*orphan_tx)};
             std::erase_if(unique_parents, [&](const auto& txid){
                 return AlreadyHaveTx(GenTxid::Txid(txid), /*include_reconsiderable=*/false);
@@ -203,8 +204,8 @@ bool TxDownloadManagerImpl::AddTxAnnouncement(NodeId peer, const GenTxid& gtxid,
 
             if (unique_parents.empty()) return true;
 
-            if (AddOrphanParentAnnouncements(unique_parents, orphan_tx->GetWitnessHash(), peer, now)) {
-                m_orphanage.AddAnnouncer(orphan_tx->GetWitnessHash(), peer);
+            if (AddOrphanParentAnnouncements(unique_parents, wtxid, peer, now)) {
+                m_orphanage.AddAnnouncer(wtxid, peer);
             }
 
             // Return even if the peer isn't an orphan resolution candidate. This would be caught by AlreadyHaveTx.

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -202,7 +202,11 @@ bool TxDownloadManagerImpl::AddTxAnnouncement(NodeId peer, const GenTxid& gtxid,
                 return AlreadyHaveTx(GenTxid::Txid(txid), /*include_reconsiderable=*/false);
             });
 
-            if (unique_parents.empty()) return true;
+            // The missing parents may have all been rejected or accepted since the orphan was added to the orphanage.
+            // Do not delete from the orphanage, as it may be queued for processing.
+            if (unique_parents.empty()) {
+                return true;
+            }
 
             if (AddOrphanParentAnnouncements(unique_parents, wtxid, peer, now)) {
                 m_orphanage.AddAnnouncer(wtxid, peer);

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -409,18 +409,19 @@ node::RejectedTxTodo TxDownloadManagerImpl::MempoolRejectedTx(const CTransaction
                 // means it was already added to vExtraTxnForCompact.
                 add_extra_compact_tx &= !m_orphanage.HaveTx(wtxid);
 
-                auto add_orphan_reso_candidate = [&](const CTransactionRef& orphan_tx, const std::vector<Txid>& unique_parents, NodeId nodeid, std::chrono::microseconds now) {
-                    if (AddOrphanParentAnnouncements(unique_parents, orphan_tx->GetWitnessHash(), nodeid, now)) {
-                        m_orphanage.AddTx(orphan_tx, nodeid);
-                    }
-                };
-
                 // If there is no candidate for orphan resolution, AddTx will not be called. This means
                 // that if a peer is overloading us with invs and orphans, they will eventually not be
                 // able to add any more transactions to the orphanage.
-                add_orphan_reso_candidate(ptx, unique_parents, nodeid, now);
-                for (const auto& candidate : m_txrequest.GetCandidatePeers(ptx)) {
-                    add_orphan_reso_candidate(ptx, unique_parents, candidate, now);
+                //
+                // Search by txid and, if the tx has a witness, wtxid
+                std::vector<NodeId> orphan_resolution_candidates{nodeid};
+                m_txrequest.GetCandidatePeers(ptx->GetHash().ToUint256(), orphan_resolution_candidates);
+                if (ptx->HasWitness()) m_txrequest.GetCandidatePeers(ptx->GetWitnessHash().ToUint256(), orphan_resolution_candidates);
+
+                for (const auto& nodeid : orphan_resolution_candidates) {
+                    if (AddOrphanParentAnnouncements(unique_parents, ptx->GetWitnessHash(), nodeid, now)) {
+                        m_orphanage.AddTx(ptx, nodeid);
+                    }
                 }
 
                 // Once added to the orphan pool, a tx is considered AlreadyHave, and we shouldn't request it anymore.

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -172,6 +172,22 @@ void TxDownloadManagerImpl::DisconnectedPeer(NodeId nodeid)
 
 }
 
+bool TxDownloadManagerImpl::AddOrphanParentAnnouncements(const std::vector<Txid>& unique_parents, const Wtxid& wtxid, NodeId nodeid, std::chrono::microseconds now)
+{
+    if (auto delay{OrphanResolutionCandidate(nodeid, wtxid, unique_parents.size())}) {
+        const auto& info = m_peer_info.at(nodeid).m_connection_info;
+
+        // Treat finding orphan resolution candidate as equivalent to the peer announcing all missing parents
+        // In the future, orphan resolution may include more explicit steps
+        for (const auto& parent_txid : unique_parents) {
+            m_txrequest.ReceivedInv(nodeid, GenTxid::Txid(parent_txid), info.m_preferred, now + *delay);
+        }
+        LogDebug(BCLog::TXPACKAGES, "added peer=%d as a candidate for resolving orphan %s\n", nodeid, wtxid.ToString());
+        return true;
+    }
+    return false;
+}
+
 bool TxDownloadManagerImpl::AddTxAnnouncement(NodeId peer, const GenTxid& gtxid, std::chrono::microseconds now)
 {
     // If this is an orphan we are trying to resolve, consider this peer as a orphan resolution candidate instead.
@@ -187,15 +203,8 @@ bool TxDownloadManagerImpl::AddTxAnnouncement(NodeId peer, const GenTxid& gtxid,
 
             if (unique_parents.empty()) return true;
 
-            if (auto delay{OrphanResolutionCandidate(peer, Wtxid::FromUint256(gtxid.GetHash()), unique_parents.size())}) {
-                m_orphanage.AddAnnouncer(Wtxid::FromUint256(gtxid.GetHash()), peer);
-
-                const auto& info = m_peer_info.at(peer).m_connection_info;
-                for (const auto& parent_txid : unique_parents) {
-                    m_txrequest.ReceivedInv(peer, GenTxid::Txid(parent_txid), info.m_preferred, now + *delay);
-                }
-
-                LogDebug(BCLog::TXPACKAGES, "added peer=%d as a candidate for resolving orphan %s\n", peer, gtxid.GetHash().ToString());
+            if (AddOrphanParentAnnouncements(unique_parents, orphan_tx->GetWitnessHash(), peer, now)) {
+                m_orphanage.AddAnnouncer(orphan_tx->GetWitnessHash(), peer);
             }
 
             // Return even if the peer isn't an orphan resolution candidate. This would be caught by AlreadyHaveTx.
@@ -401,17 +410,8 @@ node::RejectedTxTodo TxDownloadManagerImpl::MempoolRejectedTx(const CTransaction
                 add_extra_compact_tx &= !m_orphanage.HaveTx(wtxid);
 
                 auto add_orphan_reso_candidate = [&](const CTransactionRef& orphan_tx, const std::vector<Txid>& unique_parents, NodeId nodeid, std::chrono::microseconds now) {
-                    const auto& wtxid = orphan_tx->GetWitnessHash();
-                    if (auto delay{OrphanResolutionCandidate(nodeid, wtxid, unique_parents.size())}) {
-                        const auto& info = m_peer_info.at(nodeid).m_connection_info;
+                    if (AddOrphanParentAnnouncements(unique_parents, orphan_tx->GetWitnessHash(), nodeid, now)) {
                         m_orphanage.AddTx(orphan_tx, nodeid);
-
-                        // Treat finding orphan resolution candidate as equivalent to the peer announcing all missing parents
-                        // In the future, orphan resolution may include more explicit steps
-                        for (const auto& parent_txid : unique_parents) {
-                            m_txrequest.ReceivedInv(nodeid, GenTxid::Txid(parent_txid), info.m_preferred, now + *delay);
-                        }
-                        LogDebug(BCLog::TXPACKAGES, "added peer=%d as a candidate for resolving orphan %s\n", nodeid, wtxid.ToString());
                     }
                 };
 

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -341,7 +341,7 @@ void TxDownloadManagerImpl::MempoolAcceptedTx(const CTransactionRef& tx)
     m_txrequest.ForgetTxHash(tx->GetHash());
     m_txrequest.ForgetTxHash(tx->GetWitnessHash());
 
-    m_orphanage.AddChildrenToWorkSet(*tx);
+    m_orphanage.AddChildrenToWorkSet(*tx, m_opts.m_rng);
     // If it came from the orphanage, remove it. No-op if the tx is not in txorphanage.
     m_orphanage.EraseTx(tx->GetWitnessHash());
 }

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -436,7 +436,7 @@ node::RejectedTxTodo TxDownloadManagerImpl::MempoolRejectedTx(const CTransaction
                 // DoS prevention: do not allow m_orphanage to grow unbounded (see CVE-2012-3789)
                 // Note that, if the orphanage reaches capacity, it's possible that we immediately evict
                 // the transaction we just added.
-                m_orphanage.LimitOrphans(m_opts.m_max_orphan_txs, m_opts.m_rng);
+                m_orphanage.LimitOrphans(CalculateMaxOrphanBytes(), m_opts.m_rng);
             } else {
                 unique_parents.clear();
                 LogDebug(BCLog::MEMPOOL, "not keeping orphan with rejected parents %s (wtxid=%s)\n",
@@ -598,5 +598,9 @@ void TxDownloadManagerImpl::CheckIsEmpty()
 std::vector<TxOrphanage::OrphanTxBase> TxDownloadManagerImpl::GetOrphanTransactions() const
 {
     return m_orphanage.GetOrphanTransactions();
+}
+unsigned int TxDownloadManagerImpl::CalculateMaxOrphanBytes() const
+{
+    return m_opts.m_max_orphan_txs * MAX_STANDARD_TX_WEIGHT;
 }
 } // namespace node

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -586,9 +586,11 @@ CTransactionRef TxDownloadManagerImpl::GetTxToReconsider(NodeId nodeid)
 void TxDownloadManagerImpl::CheckIsEmpty(NodeId nodeid)
 {
     assert(m_txrequest.Count(nodeid) == 0);
+    assert(m_orphanage.BytesFromPeer(nodeid) == 0);
 }
 void TxDownloadManagerImpl::CheckIsEmpty()
 {
+    assert(m_orphanage.TotalOrphanBytes() == 0);
     assert(m_orphanage.Size() == 0);
     assert(m_txrequest.Size() == 0);
     assert(m_num_wtxid_peers == 0);

--- a/src/node/txdownloadman_impl.cpp
+++ b/src/node/txdownloadman_impl.cpp
@@ -601,6 +601,6 @@ std::vector<TxOrphanage::OrphanTxBase> TxDownloadManagerImpl::GetOrphanTransacti
 }
 unsigned int TxDownloadManagerImpl::CalculateMaxOrphanBytes() const
 {
-    return m_opts.m_max_orphan_txs * MAX_STANDARD_TX_WEIGHT;
+    return MAX_ORPHAN_BYTES_PER_PEER * m_peer_info.size();
 }
 } // namespace node

--- a/src/node/txdownloadman_impl.h
+++ b/src/node/txdownloadman_impl.h
@@ -205,6 +205,11 @@ protected:
      * std::nullopt if this peer cannot be added because it has reached download/orphanage limits.
      * */
     std::optional<std::chrono::seconds> OrphanResolutionCandidate(NodeId nodeid, const Wtxid& orphan_wtxid, size_t num_parents);
+
+    /** Calculate the effective global limit on orphanage bytes, which is the sum of all per-peer
+     * limits. This number may change throughout the lifetime of TxDownloadManager as the set of
+     * peers changes. */
+    unsigned int CalculateMaxOrphanBytes() const;
 };
 } // namespace node
 #endif // BITCOIN_NODE_TXDOWNLOADMAN_IMPL_H

--- a/src/node/txdownloadman_impl.h
+++ b/src/node/txdownloadman_impl.h
@@ -194,6 +194,12 @@ protected:
     /** Helper for getting deduplicated vector of Txids in vin. */
     std::vector<Txid> GetUniqueParents(const CTransaction& tx);
 
+    /** If this peer is an orphan resolution candidate for this transaction, treat the unique_parents as announced by
+     * this peer; add them as new invs to m_txrequest.
+     * @returns whether this transaction was a valid orphan resolution candidate.
+     * */
+    bool AddOrphanParentAnnouncements(const std::vector<Txid>& unique_parents, const Wtxid& wtxid, NodeId nodeid, std::chrono::microseconds now);
+
     /** Determine candidacy (and delay) for potential orphan resolution candidate.
      * @returns delay for orphan resolution if this peer is a good candidate for orphan resolution,
      * std::nullopt if this peer cannot be added because it has reached download/orphanage limits.

--- a/src/test/fuzz/txdownloadman.cpp
+++ b/src/test/fuzz/txdownloadman.cpp
@@ -279,13 +279,8 @@ FUZZ_TARGET(txdownloadman, .init = initialize)
 // peer without tracking anything (this is only for the txdownload_impl target).
 static bool HasRelayPermissions(NodeId peer) { return peer == 0; }
 
-static void CheckInvariants(const node::TxDownloadManagerImpl& txdownload_impl, size_t max_orphan_count)
+static void CheckInvariants(const node::TxDownloadManagerImpl& txdownload_impl)
 {
-    const TxOrphanage& orphanage = txdownload_impl.m_orphanage;
-
-    // Orphanage usage should never exceed what is allowed
-    Assert(orphanage.Size() <= max_orphan_count);
-
     // We should never have more than the maximum in-flight requests out for a peer.
     for (NodeId peer = 0; peer < NUM_PEERS; ++peer) {
         if (!HasRelayPermissions(peer)) {
@@ -437,7 +432,7 @@ FUZZ_TARGET(txdownloadman_impl, .init = initialize)
         auto time_skip = fuzzed_data_provider.PickValueInArray(TIME_SKIPS);
         if (fuzzed_data_provider.ConsumeBool()) time_skip *= -1;
         time += time_skip;
-        CheckInvariants(txdownload_impl, max_orphan_count);
+        CheckInvariants(txdownload_impl);
     }
     // Disconnect everybody, check that all data structures are empty.
     for (NodeId nodeid = 0; nodeid < NUM_PEERS; ++nodeid) {

--- a/src/test/fuzz/txdownloadman.cpp
+++ b/src/test/fuzz/txdownloadman.cpp
@@ -281,6 +281,8 @@ static bool HasRelayPermissions(NodeId peer) { return peer == 0; }
 
 static void CheckInvariants(const node::TxDownloadManagerImpl& txdownload_impl)
 {
+    txdownload_impl.m_orphanage.SanityCheck();
+
     // We should never have more than the maximum in-flight requests out for a peer.
     for (NodeId peer = 0; peer < NUM_PEERS; ++peer) {
         if (!HasRelayPermissions(peer)) {

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -33,7 +33,7 @@ void initialize_orphanage()
 FUZZ_TARGET(txorphan, .init = initialize_orphanage)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    FastRandomContext limit_orphans_rng{/*fDeterministic=*/true};
+    FastRandomContext orphanage_rng{/*fDeterministic=*/true};
     SetMockTime(ConsumeTime(fuzzed_data_provider));
 
     TxOrphanage orphanage;
@@ -79,7 +79,7 @@ FUZZ_TARGET(txorphan, .init = initialize_orphanage)
         // previous loop and potentially the parent of this tx.
         if (ptx_potential_parent) {
             // Set up future GetTxToReconsider call.
-            orphanage.AddChildrenToWorkSet(*ptx_potential_parent);
+            orphanage.AddChildrenToWorkSet(*ptx_potential_parent, orphanage_rng);
 
             // Check that all txns returned from GetChildrenFrom* are indeed a direct child of this tx.
             NodeId peer_id = fuzzed_data_provider.ConsumeIntegral<NodeId>();
@@ -154,7 +154,7 @@ FUZZ_TARGET(txorphan, .init = initialize_orphanage)
                     // test mocktime and expiry
                     SetMockTime(ConsumeTime(fuzzed_data_provider));
                     auto limit = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
-                    orphanage.LimitOrphans(limit, limit_orphans_rng);
+                    orphanage.LimitOrphans(limit, orphanage_rng);
                     Assert(orphanage.Size() <= limit);
                 });
 

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -75,6 +75,8 @@ FUZZ_TARGET(txorphan, .init = initialize_orphanage)
             return new_tx;
         }();
 
+        const auto wtxid{tx->GetWitnessHash()};
+
         // Trigger orphanage functions that are called using parents. ptx_potential_parent is a tx we constructed in a
         // previous loop and potentially the parent of this tx.
         if (ptx_potential_parent) {
@@ -94,6 +96,9 @@ FUZZ_TARGET(txorphan, .init = initialize_orphanage)
         LIMITED_WHILE(fuzzed_data_provider.ConsumeBool(), 10 * DEFAULT_MAX_ORPHAN_TRANSACTIONS)
         {
             NodeId peer_id = fuzzed_data_provider.ConsumeIntegral<NodeId>();
+            const auto total_bytes_start{orphanage.TotalOrphanBytes()};
+            const auto total_peer_bytes_start{orphanage.BytesFromPeer(peer_id)};
+            const auto tx_weight{GetTransactionWeight(*tx)};
 
             CallOneOf(
                 fuzzed_data_provider,
@@ -113,12 +118,29 @@ FUZZ_TARGET(txorphan, .init = initialize_orphanage)
                         bool add_tx = orphanage.AddTx(tx, peer_id);
                         // have_tx == true -> add_tx == false
                         Assert(!have_tx || !add_tx);
+
+                        if (add_tx) {
+                            Assert(orphanage.BytesFromPeer(peer_id) == tx_weight + total_peer_bytes_start);
+                            Assert(orphanage.TotalOrphanBytes() == tx_weight + total_bytes_start);
+                            Assert(tx_weight <= MAX_STANDARD_TX_WEIGHT);
+                        } else {
+                            // Peer may have been added as an announcer.
+                            if (orphanage.BytesFromPeer(peer_id) == tx_weight + total_peer_bytes_start) {
+                                Assert(orphanage.HaveTxFromPeer(tx->GetWitnessHash(), peer_id));
+                            } else {
+                                // Otherwise, there must not be any change to the peer byte count.
+                                Assert(orphanage.BytesFromPeer(peer_id) == total_peer_bytes_start);
+                            }
+
+                            // Regardless, total bytes should not have changed.
+                            Assert(orphanage.TotalOrphanBytes() == total_bytes_start);
+                        }
                     }
                     have_tx = orphanage.HaveTx(tx->GetWitnessHash());
                     {
                         bool add_tx = orphanage.AddTx(tx, peer_id);
                         // if have_tx is still false, it must be too big
-                        Assert(!have_tx == (GetTransactionWeight(*tx) > MAX_STANDARD_TX_WEIGHT));
+                        Assert(!have_tx == (tx_weight > MAX_STANDARD_TX_WEIGHT));
                         Assert(!have_tx || !add_tx);
                     }
                 },
@@ -132,23 +154,46 @@ FUZZ_TARGET(txorphan, .init = initialize_orphanage)
                         Assert(have_tx || !added_announcer);
                         // have_tx_and_peer == true -> added_announcer == false
                         Assert(!have_tx_and_peer || !added_announcer);
+
+                        // Total bytes should not have changed. If peer was added as announcer, byte
+                        // accounting must have been updated.
+                        Assert(orphanage.TotalOrphanBytes() == total_bytes_start);
+                        if (added_announcer) {
+                            Assert(orphanage.BytesFromPeer(peer_id) == tx_weight + total_peer_bytes_start);
+                        } else {
+                            Assert(orphanage.BytesFromPeer(peer_id) == total_peer_bytes_start);
+                        }
                     }
                 },
                 [&] {
                     bool have_tx = orphanage.HaveTx(tx->GetWitnessHash());
+                    bool have_tx_and_peer{orphanage.HaveTxFromPeer(wtxid, peer_id)};
                     // EraseTx should return 0 if m_orphans doesn't have the tx
                     {
+                        auto bytes_from_peer_before{orphanage.BytesFromPeer(peer_id)};
                         Assert(have_tx == orphanage.EraseTx(tx->GetWitnessHash()));
+                        if (have_tx) {
+                            Assert(orphanage.TotalOrphanBytes() == total_bytes_start - tx_weight);
+                            if (have_tx_and_peer) {
+                                Assert(orphanage.BytesFromPeer(peer_id) == bytes_from_peer_before - tx_weight);
+                            } else {
+                                Assert(orphanage.BytesFromPeer(peer_id) == bytes_from_peer_before);
+                            }
+                        } else {
+                            Assert(orphanage.TotalOrphanBytes() == total_bytes_start);
+                        }
                     }
                     have_tx = orphanage.HaveTx(tx->GetWitnessHash());
+                    have_tx_and_peer = orphanage.HaveTxFromPeer(wtxid, peer_id);
                     // have_tx should be false and EraseTx should fail
                     {
-                        Assert(!have_tx && !orphanage.EraseTx(tx->GetWitnessHash()));
+                        Assert(!have_tx && !have_tx_and_peer && !orphanage.EraseTx(tx->GetWitnessHash()));
                     }
                 },
                 [&] {
                     orphanage.EraseForPeer(peer_id);
                     Assert(!orphanage.HaveTxFromPeer(tx->GetWitnessHash(), peer_id));
+                    Assert(orphanage.BytesFromPeer(peer_id) == 0);
                 },
                 [&] {
                     // test mocktime and expiry

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -200,7 +200,7 @@ FUZZ_TARGET(txorphan, .init = initialize_orphanage)
                     SetMockTime(ConsumeTime(fuzzed_data_provider));
                     auto limit = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
                     orphanage.LimitOrphans(limit, orphanage_rng);
-                    Assert(orphanage.Size() <= limit);
+                    Assert(orphanage.TotalOrphanBytes() <= limit);
                 });
 
         }

--- a/src/test/fuzz/txorphan.cpp
+++ b/src/test/fuzz/txorphan.cpp
@@ -203,6 +203,7 @@ FUZZ_TARGET(txorphan, .init = initialize_orphanage)
                     Assert(orphanage.TotalOrphanBytes() <= limit);
                 });
 
+            orphanage.SanityCheck();
         }
         // Set tx as potential parent to be used for future GetChildren() calls.
         if (!ptx_potential_parent || fuzzed_data_provider.ConsumeBool()) {

--- a/src/test/fuzz/txrequest.cpp
+++ b/src/test/fuzz/txrequest.cpp
@@ -295,6 +295,12 @@ public:
                 tracked += m_announcements[txhash][peer].m_state != State::NOTHING;
                 inflight += m_announcements[txhash][peer].m_state == State::REQUESTED;
                 candidates += m_announcements[txhash][peer].m_state == State::CANDIDATE;
+
+                std::vector<NodeId> candidate_peers;
+                m_tracker.GetCandidatePeers(TXHASHES[txhash], candidate_peers);
+                for (const auto& peer : candidate_peers) {
+                    assert(m_announcements[txhash][peer].m_state == State::CANDIDATE || m_announcements[txhash][peer].m_state == State::REQUESTED);
+                }
             }
             assert(m_tracker.Count(peer) == tracked);
             assert(m_tracker.CountInFlight(peer) == inflight);

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -134,7 +134,7 @@ void TxOrphanage::EraseForPeer(NodeId peer)
     if (nErased > 0) LogDebug(BCLog::TXPACKAGES, "Erased %d orphan transaction(s) from peer=%d\n", nErased, peer);
 }
 
-void TxOrphanage::LimitOrphans(unsigned int max_orphans, FastRandomContext& rng)
+void TxOrphanage::LimitOrphans(unsigned int max_orphan_size, FastRandomContext& rng)
 {
     unsigned int nEvicted = 0;
     auto nNow{Now<NodeSeconds>()};
@@ -156,7 +156,7 @@ void TxOrphanage::LimitOrphans(unsigned int max_orphans, FastRandomContext& rng)
         m_next_sweep = nMinExpTime + ORPHAN_TX_EXPIRE_INTERVAL;
         if (nErased > 0) LogDebug(BCLog::TXPACKAGES, "Erased %d orphan tx due to expiration\n", nErased);
     }
-    while (m_orphans.size() > max_orphans)
+    while (m_total_orphan_size > max_orphan_size)
     {
         // Evict a random orphan:
         size_t randompos = rng.randrange(m_orphan_list.size());

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -42,6 +42,7 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
     for (const CTxIn& txin : tx->vin) {
         m_outpoint_to_orphan_it[txin.prevout].insert(ret.first);
     }
+    m_total_orphan_size += sz;
 
     LogDebug(BCLog::TXPACKAGES, "stored orphan tx %s (wtxid=%s), weight: %u (mapsz %u outsz %u)\n", hash.ToString(), wtxid.ToString(), sz,
              m_orphans.size(), m_outpoint_to_orphan_it.size());
@@ -76,6 +77,9 @@ int TxOrphanage::EraseTx(const Wtxid& wtxid)
         if (itPrev->second.empty())
             m_outpoint_to_orphan_it.erase(itPrev);
     }
+
+    const auto tx_size{it->second.GetSize()};
+    m_total_orphan_size -= tx_size;
 
     size_t old_pos = it->second.list_pos;
     assert(m_orphan_list[old_pos] == it);

--- a/src/txorphanage.cpp
+++ b/src/txorphanage.cpp
@@ -43,6 +43,8 @@ bool TxOrphanage::AddTx(const CTransactionRef& tx, NodeId peer)
         m_outpoint_to_orphan_it[txin.prevout].insert(ret.first);
     }
     m_total_orphan_size += sz;
+    auto& peer_info = m_peer_orphanage_info.try_emplace(peer).first->second;
+    peer_info.m_total_size += sz;
 
     LogDebug(BCLog::TXPACKAGES, "stored orphan tx %s (wtxid=%s), weight: %u (mapsz %u outsz %u)\n", hash.ToString(), wtxid.ToString(), sz,
              m_orphans.size(), m_outpoint_to_orphan_it.size());
@@ -56,6 +58,8 @@ bool TxOrphanage::AddAnnouncer(const Wtxid& wtxid, NodeId peer)
         Assume(!it->second.announcers.empty());
         const auto ret = it->second.announcers.insert(peer);
         if (ret.second) {
+            auto& peer_info = m_peer_orphanage_info.try_emplace(peer).first->second;
+            peer_info.m_total_size += it->second.GetSize();
             LogDebug(BCLog::TXPACKAGES, "added peer=%d as announcer of orphan tx %s\n", peer, wtxid.ToString());
             return true;
         }
@@ -80,6 +84,11 @@ int TxOrphanage::EraseTx(const Wtxid& wtxid)
 
     const auto tx_size{it->second.GetSize()};
     m_total_orphan_size -= tx_size;
+    // Decrement each announcer's m_total_size
+    for (const auto& peer : it->second.announcers) {
+        auto& peer_info = m_peer_orphanage_info.try_emplace(peer).first->second;
+        peer_info.m_total_size -= tx_size;
+    }
 
     size_t old_pos = it->second.list_pos;
     assert(m_orphan_list[old_pos] == it);
@@ -103,6 +112,7 @@ int TxOrphanage::EraseTx(const Wtxid& wtxid)
 
 void TxOrphanage::EraseForPeer(NodeId peer)
 {
+    // Zeroes out this peer's m_total_size.
     m_peer_orphanage_info.erase(peer);
 
     int nErased = 0;

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -62,7 +62,7 @@ public:
     void LimitOrphans(unsigned int max_orphans, FastRandomContext& rng);
 
     /** Add any orphans that list a particular tx as a parent into the from peer's work set */
-    void AddChildrenToWorkSet(const CTransaction& tx);
+    void AddChildrenToWorkSet(const CTransaction& tx, FastRandomContext& rng);
 
     /** Does this peer have any work to do? */
     bool HaveTxToReconsider(NodeId peer);

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_TXORPHANAGE_H
 #define BITCOIN_TXORPHANAGE_H
 
+#include <consensus/validation.h>
 #include <net.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
@@ -83,14 +84,25 @@ public:
         /** Peers added with AddTx or AddAnnouncer. */
         std::set<NodeId> announcers;
         NodeSeconds nTimeExpire;
+
+        unsigned int GetSize() const {
+            return GetTransactionWeight(*tx);
+        }
     };
 
     std::vector<OrphanTxBase> GetOrphanTransactions() const;
+
+    /** Get the total weight of all orphans. If an orphan has multiple announcers, its weight is
+     * only counted once within this total. */
+    unsigned int TotalOrphanBytes() const { return m_total_orphan_size; }
 
 protected:
     struct OrphanTx : public OrphanTxBase {
         size_t list_pos;
     };
+
+    /** Total size of all entries in m_orphans. */
+    unsigned int m_total_orphan_size{0};
 
     /** Map from wtxid to orphan transaction record. Limited by
      *  -maxorphantx/DEFAULT_MAX_ORPHAN_TRANSACTIONS */

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -60,7 +60,7 @@ public:
     void EraseForBlock(const CBlock& block);
 
     /** Limit the orphanage to the given maximum */
-    void LimitOrphans(unsigned int max_orphans, FastRandomContext& rng);
+    void LimitOrphans(unsigned int max_orphan_size, FastRandomContext& rng);
 
     /** Add any orphans that list a particular tx as a parent into the from peer's work set */
     void AddChildrenToWorkSet(const CTransaction& tx, FastRandomContext& rng);

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -96,6 +96,14 @@ public:
      * only counted once within this total. */
     unsigned int TotalOrphanBytes() const { return m_total_orphan_size; }
 
+    /** Total weight of orphans for which this peer is an announcer. If an orphan has multiple
+     * announcers, its weight will be accounted for in each PeerOrphanInfo, so the total of all
+     * peers' BytesFromPeer() may be larger than TotalOrphanBytes(). */
+    unsigned int BytesFromPeer(NodeId peer) const {
+        auto peer_it = m_peer_orphanage_info.find(peer);
+        return peer_it == m_peer_orphanage_info.end() ? 0 : peer_it->second.m_total_size;
+    }
+
 protected:
     struct OrphanTx : public OrphanTxBase {
         size_t list_pos;
@@ -114,6 +122,13 @@ protected:
          * transactions that are no longer present in orphanage; these are lazily removed in
          * GetTxToReconsider. */
         std::set<Wtxid> m_work_set;
+
+        /** Total weight of orphans for which this peer is an announcer.
+         * If orphans are provided by different peers, its weight will be accounted for in each
+         * PeerOrphanInfo, so the total of all peers' m_total_size may be larger than
+         * m_total_orphan_size. If a peer is removed as an announcer, even if the orphan still
+         * remains in the orphanage, this number will be decremented. */
+        unsigned int m_total_size{0};
     };
     std::map<NodeId, PeerOrphanInfo> m_peer_orphanage_info;
 

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -108,8 +108,14 @@ protected:
      *  -maxorphantx/DEFAULT_MAX_ORPHAN_TRANSACTIONS */
     std::map<Wtxid, OrphanTx> m_orphans;
 
-    /** Which peer provided the orphans that need to be reconsidered */
-    std::map<NodeId, std::set<Wtxid>> m_peer_work_set;
+    struct PeerOrphanInfo {
+        /** List of transactions that should be reconsidered: added to in AddChildrenToWorkSet,
+         * removed from one-by-one with each call to GetTxToReconsider. The wtxids may refer to
+         * transactions that are no longer present in orphanage; these are lazily removed in
+         * GetTxToReconsider. */
+        std::set<Wtxid> m_work_set;
+    };
+    std::map<NodeId, PeerOrphanInfo> m_peer_orphanage_info;
 
     using OrphanMap = decltype(m_orphans);
 

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -104,6 +104,10 @@ public:
         return peer_it == m_peer_orphanage_info.end() ? 0 : peer_it->second.m_total_size;
     }
 
+    /** Check consistency between PeerOrphanInfo::m_iter_list and m_orphans. Recalculate the total
+     * size of orphans per peer and ensure they match what is stored in the PeerOrphanInfo. */
+    void SanityCheck() const;
+
 protected:
     struct OrphanTx : public OrphanTxBase {
     };

--- a/src/txorphanage.h
+++ b/src/txorphanage.h
@@ -106,7 +106,6 @@ public:
 
 protected:
     struct OrphanTx : public OrphanTxBase {
-        size_t list_pos;
     };
 
     /** Total size of all entries in m_orphans. */
@@ -116,12 +115,17 @@ protected:
      *  -maxorphantx/DEFAULT_MAX_ORPHAN_TRANSACTIONS */
     std::map<Wtxid, OrphanTx> m_orphans;
 
+    using OrphanMap = decltype(m_orphans);
+
     struct PeerOrphanInfo {
         /** List of transactions that should be reconsidered: added to in AddChildrenToWorkSet,
          * removed from one-by-one with each call to GetTxToReconsider. The wtxids may refer to
          * transactions that are no longer present in orphanage; these are lazily removed in
          * GetTxToReconsider. */
         std::set<Wtxid> m_work_set;
+
+        /** Orphan transactions in vector for quick random eviction */
+        std::vector<OrphanMap::iterator> m_iter_list;
 
         /** Total weight of orphans for which this peer is an announcer.
          * If orphans are provided by different peers, its weight will be accounted for in each
@@ -130,9 +134,8 @@ protected:
          * remains in the orphanage, this number will be decremented. */
         unsigned int m_total_size{0};
     };
-    std::map<NodeId, PeerOrphanInfo> m_peer_orphanage_info;
 
-    using OrphanMap = decltype(m_orphans);
+    std::map<NodeId, PeerOrphanInfo> m_peer_orphanage_info;
 
     struct IteratorComparator
     {
@@ -146,9 +149,6 @@ protected:
     /** Index from the parents' COutPoint into the m_orphans. Used
      *  to remove orphan transactions from the m_orphans */
     std::map<COutPoint, std::set<OrphanMap::iterator, IteratorComparator>> m_outpoint_to_orphan_it;
-
-    /** Orphan transactions in vector for quick random eviction */
-    std::vector<OrphanMap::iterator> m_orphan_list;
 
     /** Timestamp for the next scheduled sweep of expired orphans */
     NodeSeconds m_next_sweep{0s};

--- a/src/txrequest.cpp
+++ b/src/txrequest.cpp
@@ -574,21 +574,13 @@ public:
         }
     }
 
-    std::vector<NodeId> GetCandidatePeers(const CTransactionRef& tx) const
+    void GetCandidatePeers(const uint256& txhash, std::vector<NodeId>& result_peers) const
     {
-        // Search by txid and, if the tx has a witness, wtxid
-        std::vector<uint256> hashes{tx->GetHash().ToUint256()};
-        if (tx->HasWitness()) hashes.emplace_back(tx->GetWitnessHash().ToUint256());
-
-        std::vector<NodeId> result_peers;
-        for (const uint256& txhash : hashes) {
-            auto it = m_index.get<ByTxHash>().lower_bound(ByTxHashView{txhash, State::CANDIDATE_DELAYED, 0});
-            while (it != m_index.get<ByTxHash>().end() && it->m_txhash == txhash && it->GetState() != State::COMPLETED) {
-                result_peers.push_back(it->m_peer);
-                ++it;
-            }
+        auto it = m_index.get<ByTxHash>().lower_bound(ByTxHashView{txhash, State::CANDIDATE_DELAYED, 0});
+        while (it != m_index.get<ByTxHash>().end() && it->m_txhash == txhash && it->GetState() != State::COMPLETED) {
+            result_peers.push_back(it->m_peer);
+            ++it;
         }
-        return result_peers;
     }
 
     void ReceivedInv(NodeId peer, const GenTxid& gtxid, bool preferred,
@@ -738,7 +730,7 @@ size_t TxRequestTracker::CountInFlight(NodeId peer) const { return m_impl->Count
 size_t TxRequestTracker::CountCandidates(NodeId peer) const { return m_impl->CountCandidates(peer); }
 size_t TxRequestTracker::Count(NodeId peer) const { return m_impl->Count(peer); }
 size_t TxRequestTracker::Size() const { return m_impl->Size(); }
-std::vector<NodeId> TxRequestTracker::GetCandidatePeers(const CTransactionRef& tx) const { return m_impl->GetCandidatePeers(tx); }
+void TxRequestTracker::GetCandidatePeers(const uint256& txhash, std::vector<NodeId>& result_peers) const { return m_impl->GetCandidatePeers(txhash, result_peers); }
 void TxRequestTracker::SanityCheck() const { m_impl->SanityCheck(); }
 
 void TxRequestTracker::PostGetRequestableSanityCheck(std::chrono::microseconds now) const

--- a/src/txrequest.h
+++ b/src/txrequest.h
@@ -195,8 +195,9 @@ public:
     /** Count how many announcements are being tracked in total across all peers and transaction hashes. */
     size_t Size() const;
 
-    /** For some tx return all peers with non-COMPLETED announcements for its txid or wtxid. The resulting vector may contain duplicate NodeIds. */
-    std::vector<NodeId> GetCandidatePeers(const CTransactionRef& tx) const;
+    /** For some txhash (txid or wtxid), finds all peers with non-COMPLETED announcements and appends them to
+     * result_peers. Does not try to ensure that result_peers contains no duplicates. */
+    void GetCandidatePeers(const uint256& txhash, std::vector<NodeId>& result_peers) const;
 
     /** Access to the internal priority computation (testing only) */
     uint64_t ComputePriority(const uint256& txhash, NodeId peer, bool preferred) const;

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -153,8 +153,8 @@ class InvalidTxRequestTest(BitcoinTestFramework):
             orphan_tx_pool[i].vin.append(CTxIn(outpoint=COutPoint(i, 333)))
             orphan_tx_pool[i].vout.append(CTxOut(nValue=11 * COIN, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
 
-        with node.assert_debug_log(['orphanage overflow, removed 1 tx']):
-            node.p2ps[0].send_txs_and_test(orphan_tx_pool, node, success=False)
+        node.p2ps[0].send_txs_and_test(orphan_tx_pool, node, success=False)
+        self.wait_until(lambda: len(node.getorphantxs()) <= 100)
 
         self.log.info('Test orphan with rejected parents')
         rejected_parent = CTransaction()
@@ -165,8 +165,8 @@ class InvalidTxRequestTest(BitcoinTestFramework):
             node.p2ps[0].send_txs_and_test([rejected_parent], node, success=False)
 
         self.log.info('Test that a peer disconnection causes erase its transactions from the orphan pool')
-        with node.assert_debug_log(['Erased 100 orphan transaction(s) from peer=26']):
-            self.reconnect_p2p(num_connections=1)
+        self.reconnect_p2p(num_connections=1)
+        self.wait_until(lambda: len(node.getorphantxs()) == 0)
 
         self.log.info('Test that a transaction in the orphan pool is included in a new tip block causes erase this transaction from the orphan pool')
         tx_withhold_until_block_A = CTransaction()

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -147,14 +147,14 @@ class InvalidTxRequestTest(BitcoinTestFramework):
         self.wait_until(lambda: 1 == len(node.getpeerinfo()), timeout=12)  # p2ps[1] is no longer connected
         assert_equal(expected_mempool, set(node.getrawmempool()))
 
-        self.log.info('Test orphan pool overflow')
+        self.log.info('Test orphanage can keep more than 100 transactions')
         orphan_tx_pool = [CTransaction() for _ in range(101)]
         for i in range(len(orphan_tx_pool)):
             orphan_tx_pool[i].vin.append(CTxIn(outpoint=COutPoint(i, 333)))
             orphan_tx_pool[i].vout.append(CTxOut(nValue=11 * COIN, scriptPubKey=SCRIPT_PUB_KEY_OP_TRUE))
 
         node.p2ps[0].send_txs_and_test(orphan_tx_pool, node, success=False)
-        self.wait_until(lambda: len(node.getorphantxs()) <= 100)
+        self.wait_until(lambda: len(node.getorphantxs()) == 101)
 
         self.log.info('Test orphan with rejected parents')
         rejected_parent = CTransaction()

--- a/test/functional/p2p_opportunistic_1p1c.py
+++ b/test/functional/p2p_opportunistic_1p1c.py
@@ -7,12 +7,19 @@ Test opportunistic 1p1c package submission logic.
 """
 
 from decimal import Decimal
+import random
 import time
+
+from test_framework.blocktools import MAX_STANDARD_TX_WEIGHT
 from test_framework.mempool_util import (
     fill_mempool,
 )
 from test_framework.messages import (
     CInv,
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxOut,
     CTxInWitness,
     MAX_BIP125_RBF_SEQUENCE,
     MSG_WTX,
@@ -21,12 +28,20 @@ from test_framework.messages import (
     tx_from_hex,
 )
 from test_framework.p2p import (
+    NONPREF_PEER_TX_DELAY,
     P2PInterface,
+    TXID_RELAY_DELAY,
+)
+from test_framework.script import (
+    CScript,
+    OP_NOP,
+    OP_RETURN,
 )
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     assert_greater_than,
+    assert_greater_than_or_equal,
 )
 from test_framework.wallet import (
     MiniWallet,
@@ -375,6 +390,136 @@ class PackageRelayTest(BitcoinTestFramework):
         result_missing_parent = node.submitpackage(package_hex_missing_parent)
         assert_equal(result_missing_parent["package_msg"], "package-not-child-with-unconfirmed-parents")
 
+    def create_large_orphan(self):
+        """Create huge orphan transaction"""
+        tx = CTransaction()
+        # Nonexistent UTXO
+        tx.vin = [CTxIn(COutPoint(random.randrange(1 << 256), random.randrange(1, 100)))]
+        tx.wit.vtxinwit = [CTxInWitness()]
+        tx.wit.vtxinwit[0].scriptWitness.stack = [CScript([OP_NOP] * 390000)]
+        tx.vout = [CTxOut(100, CScript([OP_RETURN, b'a' * 20]))]
+        return tx
+
+    def create_small_orphan(self):
+        """Create small orphan transaction"""
+        tx = CTransaction()
+        # Nonexistent UTXO
+        tx.vin = [CTxIn(COutPoint(random.randrange(1 << 256), random.randrange(1, 100)))]
+        tx.wit.vtxinwit = [CTxInWitness()]
+        tx.wit.vtxinwit[0].scriptWitness.stack = [CScript([OP_NOP] * 5)]
+        tx.vout = [CTxOut(100, CScript([OP_RETURN, b'a' * 3]))]
+        return tx
+
+    @cleanup
+    def test_orphanage_dos_large(self):
+        self.log.info("Test that the node can still resolve orphans when peers use lots of orphanage space")
+        node = self.nodes[0]
+        node.setmocktime(int(time.time()))
+
+        peer_normal = node.add_p2p_connection(P2PInterface())
+        peer_doser = node.add_p2p_connection(P2PInterface())
+
+        self.log.info("Create very large orphans to be sent by DoSy peers (may take a while)")
+        large_orphans = [self.create_large_orphan() for _ in range(60)]
+        # Check to make sure these are orphans, within max standard size (to be accepted into the orphanage)
+        for large_orphan in large_orphans:
+            assert_greater_than_or_equal(100000, large_orphan.get_vsize())
+            assert_greater_than(MAX_STANDARD_TX_WEIGHT, large_orphan.get_weight())
+            assert_greater_than_or_equal(3 * large_orphan.get_vsize(), 2 * 100000)
+            testres = node.testmempoolaccept([large_orphan.serialize().hex()])
+            assert not testres[0]["allowed"]
+            assert_equal(testres[0]["reject-reason"], "missing-inputs")
+
+        num_individual_dosers = 20
+        self.log.info(f"Connect {num_individual_dosers} peers and send a very large orphan from each one (may take a while)")
+        # This test assumes that unrequested transactions are processed (skipping inv and
+        # getdata steps because they require going through request delays)
+        # Connect 20 peers and have each of them send a large orphan.
+        for large_orphan in large_orphans[:num_individual_dosers]:
+            peer_doser_individual = node.add_p2p_connection(P2PInterface())
+            peer_doser_individual.send_and_ping(msg_tx(large_orphan))
+            node.bumpmocktime(NONPREF_PEER_TX_DELAY + TXID_RELAY_DELAY)
+            peer_doser_individual.wait_for_getdata([large_orphan.vin[0].prevout.hash])
+
+        # Make sure that these transactions are going through the orphan handling codepaths.
+        # Subsequent rounds will not wait for getdata because the time mocking will cause the
+        # normal package request to time out.
+        self.wait_until(lambda: len(node.getorphantxs()) == num_individual_dosers)
+
+        self.log.info("Send an orphan from a non-DoSy peer. Its orphan should not be evicted.")
+        low_fee_parent = self.create_tx_below_mempoolminfee(self.wallet)
+        high_fee_child = self.wallet.create_self_transfer(utxo_to_spend=low_fee_parent["new_utxo"], fee_rate=20*FEERATE_1SAT_VB)
+
+        # Announce
+        orphan_wtxid = high_fee_child["wtxid"]
+        orphan_tx = high_fee_child["tx"]
+        orphan_inv = CInv(t=MSG_WTX, h=int(orphan_wtxid, 16))
+
+        # Wait for getdata
+        peer_normal.send_and_ping(msg_inv([orphan_inv]))
+        node.bumpmocktime(NONPREF_PEER_TX_DELAY)
+        peer_normal.wait_for_getdata([int(orphan_wtxid, 16)])
+        peer_normal.send_and_ping(msg_tx(orphan_tx))
+
+        # Wait for parent request
+        parent_txid_int = int(low_fee_parent["txid"], 16)
+        node.bumpmocktime(NONPREF_PEER_TX_DELAY + TXID_RELAY_DELAY)
+        peer_normal.wait_for_getdata([parent_txid_int])
+
+        self.log.info("Send another round of very large orphans from a DoSy peer")
+        for large_orphan in large_orphans[40:60]:
+            peer_doser.send_and_ping(msg_tx(large_orphan))
+
+        self.log.info("Provide the orphan's parent. This 1p1c package should be successfully accepted.")
+        peer_normal.send_and_ping(msg_tx(low_fee_parent["tx"]))
+        assert_equal(node.getmempoolentry(orphan_tx.rehash())["ancestorcount"], 2)
+
+    @cleanup
+    def test_orphanage_dos_many(self):
+        self.log.info("Test that the node can still resolve orphans when peers are sending tons of orphans")
+        node = self.nodes[0]
+        node.setmocktime(int(time.time()))
+
+        peer_normal = node.add_p2p_connection(P2PInterface())
+
+        self.log.info("Send sets of 200 orphans from 10 DoSy peers")
+        # Each of the 10 peers creates a distinct set of orphans
+        for _ in range(10):
+            peer_doser_batch = node.add_p2p_connection(P2PInterface())
+            for _ in range(200):
+                peer_doser_batch.send_and_ping(msg_tx(self.create_small_orphan()))
+
+        self.log.info("Send an orphan from a non-DoSy peer. Its orphan should not be evicted.")
+        low_fee_parent = self.create_tx_below_mempoolminfee(self.wallet)
+        high_fee_child = self.wallet.create_self_transfer(utxo_to_spend=low_fee_parent["new_utxo"], fee_rate=20*FEERATE_1SAT_VB)
+
+        # Announce
+        orphan_wtxid = high_fee_child["wtxid"]
+        orphan_tx = high_fee_child["tx"]
+        orphan_inv = CInv(t=MSG_WTX, h=int(orphan_wtxid, 16))
+
+        # Wait for getdata
+        peer_normal.send_and_ping(msg_inv([orphan_inv]))
+        node.bumpmocktime(NONPREF_PEER_TX_DELAY)
+        peer_normal.wait_for_getdata([int(orphan_wtxid, 16)])
+        peer_normal.send_and_ping(msg_tx(orphan_tx))
+
+        # Wait for parent request
+        parent_txid_int = int(low_fee_parent["txid"], 16)
+        node.bumpmocktime(NONPREF_PEER_TX_DELAY + TXID_RELAY_DELAY)
+        peer_normal.wait_for_getdata([parent_txid_int])
+
+        self.log.info("Send the same 150 orphans from 10 DoSy peers")
+        shared_orphans = [self.create_small_orphan() for _ in range(150)]
+        for _ in range(10):
+            peer_doser_shared = node.add_p2p_connection(P2PInterface())
+            for orphan in shared_orphans:
+                peer_doser_shared.send_and_ping(msg_tx(orphan))
+
+        self.log.info("Provide the orphan's parent. This 1p1c package should be successfully accepted.")
+        peer_normal.send_and_ping(msg_tx(low_fee_parent["tx"]))
+        assert_equal(node.getmempoolentry(orphan_tx.rehash())["ancestorcount"], 2)
+
     def run_test(self):
         node = self.nodes[0]
         # To avoid creating transactions with the same txid (can happen if we set the same feerate
@@ -403,6 +548,9 @@ class PackageRelayTest(BitcoinTestFramework):
 
         self.log.info("Check opportunistic 1p1c logic when 2 candidate children exist (parent txid == wtxid)")
         self.test_low_and_high_child(self.wallet_nonsegwit)
+
+        self.test_orphanage_dos_large()
+        self.test_orphanage_dos_many()
 
         self.test_orphan_consensus_failure()
         self.test_parent_consensus_failure()

--- a/test/functional/p2p_orphan_handling.py
+++ b/test/functional/p2p_orphan_handling.py
@@ -66,8 +66,8 @@ def cleanup(func):
 
 class PeerTxRelayer(P2PTxInvStore):
     """A P2PTxInvStore that also remembers all of the getdata and tx messages it receives."""
-    def __init__(self):
-        super().__init__()
+    def __init__(self, wtxidrelay=True):
+        super().__init__(wtxidrelay=wtxidrelay)
         self._tx_received = []
         self._getdata_received = []
 
@@ -402,7 +402,7 @@ class OrphanHandlingTest(BitcoinTestFramework):
         node = self.nodes[0]
         peer1 = node.add_p2p_connection(PeerTxRelayer())
         peer2 = node.add_p2p_connection(PeerTxRelayer())
-        peer3 = node.add_p2p_connection(PeerTxRelayer())
+        peer3 = node.add_p2p_connection(PeerTxRelayer(wtxidrelay=False))
 
         self.log.info("Test that an orphan with rejected parents, along with any descendants, cannot be retried with an alternate witness")
         parent_low_fee_nonsegwit = self.wallet_nonsegwit.create_self_transfer(fee_rate=0)

--- a/test/functional/p2p_orphan_handling.py
+++ b/test/functional/p2p_orphan_handling.py
@@ -45,11 +45,6 @@ TXREQUEST_TIME_SKIP = NONPREF_PEER_TX_DELAY + TXID_RELAY_DELAY + OVERLOADED_PEER
 DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100
 
 def cleanup(func):
-    # Time to fastfoward (using setmocktime) in between subtests to ensure they do not interfere with
-    # one another, in seconds. Equal to 12 hours, which is enough to expire anything that may exist
-    # (though nothing should since state should be cleared) in p2p data structures.
-    LONG_TIME_SKIP = 12 * 60 * 60
-
     def wrapper(self):
         try:
             func(self)
@@ -57,10 +52,11 @@ def cleanup(func):
             # Clear mempool
             self.generate(self.nodes[0], 1)
             self.nodes[0].disconnect_p2ps()
-            self.nodes[0].bumpmocktime(LONG_TIME_SKIP)
             # Check that mempool and orphanage have been cleared
             self.wait_until(lambda: len(self.nodes[0].getorphantxs()) == 0)
             assert_equal(0, len(self.nodes[0].getrawmempool()))
+
+            self.restart_node(0, extra_args=["-persistmempool=0"])
             self.wallet.rescan_utxos(include_mempool=True)
     return wrapper
 

--- a/test/functional/p2p_orphan_handling.py
+++ b/test/functional/p2p_orphan_handling.py
@@ -588,47 +588,6 @@ class OrphanHandlingTest(BitcoinTestFramework):
         self.wait_until(lambda: len(node.getorphantxs()) == 0)
 
     @cleanup
-    def test_max_orphan_amount(self):
-        self.log.info("Check that we never exceed our storage limits for orphans")
-
-        node = self.nodes[0]
-        self.generate(self.wallet, 1)
-        peer_1 = node.add_p2p_connection(P2PInterface())
-
-        self.log.info("Check that orphanage is empty on start of test")
-        assert len(node.getorphantxs()) == 0
-
-        self.log.info("Filling up orphanage with " + str(DEFAULT_MAX_ORPHAN_TRANSACTIONS) + "(DEFAULT_MAX_ORPHAN_TRANSACTIONS) orphans")
-        orphans = []
-        parent_orphans = []
-        for _ in range(DEFAULT_MAX_ORPHAN_TRANSACTIONS):
-            tx_parent_1 = self.wallet.create_self_transfer()
-            tx_child_1 = self.wallet.create_self_transfer(utxo_to_spend=tx_parent_1["new_utxo"])
-            parent_orphans.append(tx_parent_1["tx"])
-            orphans.append(tx_child_1["tx"])
-            peer_1.send_message(msg_tx(tx_child_1["tx"]))
-
-        peer_1.sync_with_ping()
-        orphanage = node.getorphantxs()
-        self.wait_until(lambda: len(node.getorphantxs()) == DEFAULT_MAX_ORPHAN_TRANSACTIONS)
-
-        for orphan in orphans:
-            assert tx_in_orphanage(node, orphan)
-
-        self.log.info("Check that we do not add more than the max orphan amount")
-        tx_parent_1 = self.wallet.create_self_transfer()
-        tx_child_1 = self.wallet.create_self_transfer(utxo_to_spend=tx_parent_1["new_utxo"])
-        peer_1.send_and_ping(msg_tx(tx_child_1["tx"]))
-        parent_orphans.append(tx_parent_1["tx"])
-        orphanage = node.getorphantxs()
-        assert_equal(len(orphanage), DEFAULT_MAX_ORPHAN_TRANSACTIONS)
-
-        self.log.info("Clearing the orphanage")
-        for index, parent_orphan in enumerate(parent_orphans):
-            peer_1.send_and_ping(msg_tx(parent_orphan))
-        self.wait_until(lambda: len(node.getorphantxs()) == 0)
-
-    @cleanup
     def test_orphan_handling_prefer_outbound(self):
         self.log.info("Test that the node prefers requesting from outbound peers")
         node = self.nodes[0]
@@ -812,7 +771,6 @@ class OrphanHandlingTest(BitcoinTestFramework):
         self.test_same_txid_orphan()
         self.test_same_txid_orphan_of_orphan()
         self.test_orphan_txid_inv()
-        self.test_max_orphan_amount()
         self.test_orphan_handling_prefer_outbound()
         self.test_announcers_before_and_after()
         self.test_parents_change()

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -928,8 +928,8 @@ class P2PDataStore(P2PInterface):
 
 class P2PTxInvStore(P2PInterface):
     """A P2PInterface which stores a count of how many times each txid has been announced."""
-    def __init__(self):
-        super().__init__()
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
         self.tx_invs_received = defaultdict(int)
 
     def on_inv(self, message):


### PR DESCRIPTION
TODO

- [x] bench
- [ ] unit test for LimitOrphans?
- [x] fuzz that we never go over limit
- [ ] adapt existing functional tests to use size to fix the failures at [p2p] limit orphanage by total tx size instead of count

defer:
- outbounds and inbounds different limits
- delete `-maxorphantxs`, docs